### PR TITLE
Copy Jepsen tests for Cassandra and Scalar DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Run tests with Jepsen Docker
 1. Clone [Jepsen repository](https://github.com/jepsen-io/jepsen)
-2. Configure to mount `scalar-jepsen` directory by editing `${JEPSEN}/docker/docker-compose.dev.yml` like the following
+2. Configure to mount `scalar-jepsen` directory by editing `${JEPSEN_ROOT}/docker/docker-compose.dev.yml` like the following
 
 ```yaml
    control:
@@ -13,7 +13,7 @@
 3. Start docker with `--dev` option
 
 ```sh
-$ cd ${JEPSEN}/docker
+$ cd ${JEPSEN_ROOT}/docker
 $ ./up.sh --dev
 ```
 
@@ -40,8 +40,8 @@ sudo apt install openjdk-8-jre
 ```
 
 3. Install Leiningen (https://leiningen.org/) on the control machine
-4. Make a SSH key pair on the control machine
-5. Add the public key to login nodes as root on each node
+4. Make an SSH key pair for Jepsen to login nodes from the control machine
+5. Register the public key as root on each node
 
 ```sh
 $ sudo echo ssh-rsa ... >> /root/.ssh/authorized_keys

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
    control:
      volumes:
        - ${JEPSEN_ROOT}:/jepsen # Mounts $JEPSEN_ROOT on host to /jepsen control container
-       - ${SCALAR_JEPSEN}:/scalar-jepsen
+       - ${SCALAR_JEPSEN_ROOT}:/scalar-jepsen # $SCALAR_JEPSEN_ROOT is the path of this repository on host
 ```
 
 3. Start docker with `--dev` option

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ $ ./up.sh --dev
 
 # Run tests without Docker
 1. Launch debian machines as a control machine and Cassandra nodes
-  - We recommend 1 control machine and 5 node's machines
-    - You can decrease the number of nodes. If it's decreased, you need to specify the nodes when a test starts.
+  - We recommend 1 control machine and 5 node machines
+    - You can decrease the number of nodes. If you do so then you will need to specify the nodes when starting a test.
 2. Install Java8 on each machine
 ```sh
 sudo apt install openjdk-8-jre

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+
+# Run tests with Jepsen Docker
+1. Clone [Jepsen repository](https://github.com/jepsen-io/jepsen)
+2. Configure to mount `scalar-jepsen` directory by editing `${JEPSEN}/docker/docker-compose.dev.yml` like the following
+
+```yaml
+   control:
+     volumes:
+       - ${JEPSEN_ROOT}:/jepsen # Mounts $JEPSEN_ROOT on host to /jepsen control container
+       - ${SCALAR_JEPSEN}:/scalar-jepsen
+```
+
+3. Start docker with `--dev` option
+
+```sh
+$ cd ${JEPSEN}/docker
+$ ./up.sh --dev
+```
+
+4. Run tests in `jepsen-control`
+  - You can login `jepsen-control` by the following command
+  ```sh
+  $ docker exec -it jepsen-control bash
+  ```
+
+```
+# cd /scalar-jepsen/cassandra
+# lein run test --test lwt
+```
+
+  - Check README in each test for more detail
+
+# Run tests without Docker
+1. Launch debian machines as a control machine and Cassandra nodes
+  - We recommend 1 control machine and 5 node's machines
+    - You can decrease the number of nodes. If it's decreased, you need to specify the nodes when a test starts.
+2. Install Java8 on each machine
+```sh
+sudo apt install openjdk-8-jre
+```
+
+3. Install Leiningen (https://leiningen.org/) on the control machine
+4. Make a SSH key pair on the control machine
+5. Add the public key to login nodes as root on each node
+
+```sh
+$ sudo echo ssh-rsa ... >> /root/.ssh/authorized_keys
+```
+
+6. Configure `/etc/hosts` on each machine
+
+```sh
+$ sudo sh -c "cat << EOF >> /etc/hosts
+<NODE1_IP> n1
+<NODE2_IP> n2
+<NODE3_IP> n3
+<NODE4_IP> n4
+<NODE5_IP> n5
+EOF"
+```
+
+7. Run a test on the control machine
+
+```sh
+$ cd ${SCALAR_JEPSEN}/cassandra
+$ lein run test --test lwt --ssh-private-key ~/.ssh/id_rsa
+```

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -13,16 +13,13 @@ This is based on [riptano's jepsen](https://github.com/riptano/jepsen/tree/cassa
 
 You will probably need to increase the amount of memory that you make available to Docker in order to run these tests with Docker. We have had success using 8GB of memory and 2GB of swap. More, if you can spare it, is probably better.
 
-### Start the Docker Container
+### Run a test
 
-- Fire up docker
-```sh
-cd ${JEPSEN}/docker
-./up.sh
+```
+# in jepsen-control
+
+$ cd ${SCALAR_JEPSEN}/cassandra
+$ lein run test --test lwt --nemesis bridge --join bootstrap
 ```
 
-### Run tests
-
-`lein run test --test lwt --nemesis bridge --join bootstrap`
-
-See `lein run test --help` for full options
+- See `lein run test --help` for full options

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -1,0 +1,28 @@
+# Cassandra tests with Jepsen
+
+This is based on [riptano's jepsen](https://github.com/riptano/jepsen/tree/cassandra/cassandra).
+
+## Current status
+- Supports Apache Cassandra 3.11.x
+- Support `collections.map-test`, `collections.set-test`, `batch-test`, `counter-test`(only add) and `lwt-test`
+  - Removed `lww-test` and `mv-test`
+
+## How to test
+
+### Docker settings
+
+You will probably need to increase the amount of memory that you make available to Docker in order to run these tests with Docker. We have had success using 8GB of memory and 2GB of swap. More, if you can spare it, is probably better.
+
+### Start the Docker Container
+
+- Fire up docker
+```sh
+cd ${JEPSEN}/docker
+./up.sh
+```
+
+### Run tests
+
+`lein run test --test lwt --nemesis bridge --join bootstrap`
+
+See `lein run test --help` for full options

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -14,6 +14,9 @@ This is based on [riptano's jepsen](https://github.com/riptano/jepsen/tree/cassa
 You will probably need to increase the amount of memory that you make available to Docker in order to run these tests with Docker. We have had success using 8GB of memory and 2GB of swap. More, if you can spare it, is probably better.
 
 ### Run a test
+1. Start the Docker nodes or multiple machines and log into jepsen-control (as explained [here](https://github.com/scalar-labs/scalar-jepsen/tree/README.md)).
+
+2. Run a test
 
 ```
 # in jepsen-control

--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -1,0 +1,12 @@
+(defproject cassandra "0.1.0-SNAPSHOT"
+  :description "Jepsen testing for Cassandra"
+  :url "http://github.com/scalar-labs/jepsen"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/java.jmx "0.3.1"]
+                 [jepsen "0.1.13"]
+                 [cc.qbits/alia "4.3.1"]
+                 [cc.qbits/hayt "4.1.0"]]
+  :main cassandra.runner
+  :aot [cassandra.runner])

--- a/cassandra/src/cassandra/batch.clj
+++ b/cassandra/src/cassandra/batch.clj
@@ -1,0 +1,100 @@
+(ns cassandra.batch
+  (:require [cassandra.core :refer :all]
+            [cassandra.conductors :as conductors]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]]
+            [knossos.model :as model]
+            [qbits.alia :as alia]
+            [qbits.hayt]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all])
+  (:import (clojure.lang ExceptionInfo)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
+                                                ReadTimeoutException
+                                                WriteTimeoutException
+                                                UnavailableException)))
+
+(defrecord BatchSetClient [tbl-created? conn]
+  client/Client
+  (open! [_ test _]
+    (let [cluster (alia/cluster {:contact-points (map name (:nodes test))})
+          conn (alia/connect cluster)]
+      (BatchSetClient. tbl-created? conn)))
+
+  (setup! [_ test]
+    (locking tbl-created?
+      (when (compare-and-set! tbl-created? false true)
+        (alia/execute conn (create-keyspace :jepsen_keyspace
+                                            (if-exists false)
+                                            (with {:replication {"class"              "SimpleStrategy"
+                                                                 "replication_factor" (:rf test)}})))
+        (alia/execute conn (use-keyspace :jepsen_keyspace))
+        (alia/execute conn (create-table :bat
+                                         (if-exists false)
+                                         (column-definitions {:pid         :int
+                                                              :cid         :int
+                                                              :value       :int
+                                                              :primary-key [:pid :cid]})))
+        (alia/execute conn (alter-table :bat (with {:compaction {:class :SizeTieredCompactionStrategy}}))))))
+
+  (invoke! [this test op]
+    (alia/execute conn (use-keyspace :jepsen_keyspace))
+    (try
+      (case (:f op)
+        :add (let [value (:value op)]
+               (alia/execute conn
+                             (str "BEGIN BATCH "
+                                  "INSERT INTO bat (pid, cid, value) VALUES ("
+                                  value ", 0," value "); "
+                                  "INSERT INTO bat (pid, cid, value) VALUES ("
+                                  value ", 1," value "); "
+                                  "APPLY BATCH;")
+                             {:consistency :quorum})
+               (assoc op :type :ok))
+        :read (let [results (alia/execute conn
+                                          (select :bat)
+                                          {:consistency-level :all
+                                           :retry-policy      aggressive-read})
+                    value-a (->> results
+                                 (filter (fn [ret] (= (:cid ret) 0)))
+                                 (map :value)
+                                 (into (sorted-set)))
+                    value-b (->> results
+                                 (filter (fn [ret] (= (:cid ret) 1)))
+                                 (map :value)
+                                 (into (sorted-set)))]
+                (if-not (= value-a value-b)
+                  (assoc op :type :fail :value [value-a value-b])
+                  (assoc op :type :ok :value value-a))))
+
+      (catch ExceptionInfo e
+        (let [e (class (:exception (ex-data e)))]
+          (condp = e
+            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
+            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
+            UnavailableException (assoc op :type :fail, :error :unavailable)
+            NoHostAvailableException (do
+                                       (info "All the servers are down - waiting 2s")
+                                       (Thread/sleep 2000)
+                                       (assoc op :type :fail, :error :no-host-available)))))))
+
+  (close! [_ _]
+    (info "Closing client conn" conn)
+    (alia/shutdown conn))
+
+  (teardown! [_ _]))
+
+(defn batch-test
+  [opts]
+  (merge (cassandra-test (str "batch-set-" (:suffix opts))
+                         {:client    (BatchSetClient. (atom false) nil)
+                          :model     (model/set)
+                          :checker   (checker/set)
+                          :generator (gen/phases
+                                       (->> [(adds)]
+                                            (conductors/std-gen opts))
+                                       (gen/delay 5 (read-once)))})
+         opts))

--- a/cassandra/src/cassandra/checker.clj
+++ b/cassandra/src/cassandra/checker.clj
@@ -1,0 +1,147 @@
+(ns cassandra.checker
+  (require [clojure.core.reducers :as r]
+           [clojure.tools.logging :refer [debug info warn]]
+           [knossos.core :as knossos])
+  (:import jepsen.checker.Checker))
+
+(defn complete-rewrite-fold-op
+  "Temporarily copied from knossos.history. Rewrites failed CAS to :read."
+  [[history index] op]
+  (condp = (:type op)
+    ; An invocation; remember where it is
+    :invoke
+    (do
+      ; Enforce the singlethreaded constraint.
+      (when-let [prior (get index (:process op))]
+        (throw (RuntimeException.
+                 (str "Process " (:process op) " already running "
+                      (pr-str (get history prior))
+                      ", yet attempted to invoke "
+                      (pr-str op) " concurrently"))))
+
+      [(conj! history op)
+       (assoc! index (:process op) (dec (count history)))])
+
+    ; A completion; fill in the completed value.
+    :ok
+    (let [i           (get index (:process op))
+          _           (assert i)
+          invocation  (nth history i)
+          value       (or (:value invocation) (:value op))
+          invocation' (assoc invocation :value value)]
+      [(-> history
+           (assoc! i invocation')
+           (conj! op))
+       (dissoc! index (:process op))])
+
+    ; A failure; fill in either value.
+    :fail
+    (let [i           (get index (:process op))
+          _           (assert i)
+          invocation  (nth history i)
+          value       (or (:value invocation) (:value op))
+          [invocation' op'] (if (and (= :cas (:f op)) (number? (:value op)))
+                                  [(assoc invocation :f :read :value (:value op))
+                                   (assoc op :f :read :type :ok)]
+                                  [(assoc invocation :value value) (assoc op :value value)])]
+      [(-> history
+           (assoc! i invocation')
+           (conj! op'))
+       (dissoc! index (:process op))])
+
+    ; No change for info messages
+    :info
+    [(conj! history op) index]))
+
+(defn complete-and-rewrite
+  "Temporarily copied from knossos.history until we figure out if rewriting history
+  is a good idea."
+  [history]
+  (->> history
+       (reduce complete-rewrite-fold-op
+               [(transient []) (transient {})])
+       first
+       persistent!))
+
+(defn enhanced-analysis
+  "An enhanced version of analysis in knossos.core which rewrites failed CAS to
+  :read"
+  [model history]
+  (let [history+            (complete-and-rewrite history)
+        [lin-prefix worlds] (knossos/linearizable-prefix-and-worlds model history+)
+        valid?              (= (count history+) (count lin-prefix))
+        evil-op             (when-not valid?
+                              (nth history+ (count lin-prefix)))
+
+        ; Remove worlds with equivalent states
+        worlds              (->> worlds
+                                 ; Wait, is this backwards? Should degenerate-
+                                 ; world-key be the key in this map?
+                                 (r/map (juxt knossos/degenerate-world-key identity))
+                                 (into {})
+                                 vals)]
+    (if valid?
+      {:valid?              true
+       :linearizable-prefix lin-prefix
+       :worlds              worlds}
+      {:valid?                   false
+       :linearizable-prefix      lin-prefix
+       :last-consistent-worlds   worlds
+       :inconsistent-op          evil-op
+       :inconsistent-transitions (map (fn [w]
+                                      [(:model w)
+                                       (-> w :model (knossos/step evil-op) :msg)])
+                                      worlds)})))
+
+(def enhanced-linearizable
+  "A linearizability checker using Knossos that rewrites failed CAS operations
+  to :read, since these are returned in Cassandra from failed LWT CAS"
+  (reify Checker
+    (check [this test model history]
+      (enhanced-analysis model history))))
+
+(defn ec-history->latencies
+  [threshold]
+  (fn [history]
+    (->> history
+         (reduce (fn [[history invokes] op]
+                   (cond
+                                        ;New write
+                     (and (= :invoke (:type op)) (= :assoc (:f op)))
+                     [(conj! history op)
+                      (assoc! invokes (:v (:value op))
+                              [(dec (count history)) #{} (:time op)])]
+
+                                        ; Check propagation of writes in this read
+                     (and (= :ok (:type op)) (= :read (:f op)))
+                     (reduce (fn [[history invokes] value]
+                               (if-let [[invoke-idx nodes start-time] (get invokes value)]
+                                        ; We have an invocation for this value
+                                 (cond
+                                   (= (count (conj nodes (:node op))) threshold)
+                                   (let [invoke (get history invoke-idx)
+                                        ; Compute latency
+                                         l    (- (:time op) start-time)
+                                         op (assoc op :latency l)]
+                                     [(-> history
+                                          (assoc! invoke-idx
+                                                  (assoc invoke :latency l, :completion op))
+                                          (conj! op))
+                                      (dissoc! invokes value)])
+
+                                   (= (count nodes) 0)
+                                   [history (assoc! invokes value
+                                                    [invoke-idx (conj nodes (:node op)) (:time op)])]
+
+                                   :default
+                                   [history (assoc! invokes value
+                                                    [invoke-idx (conj nodes (:node op)) start-time])])
+                                 [history invokes]))
+                             [history invokes]
+                             (vals (:value op)))
+
+                     :default
+                     [history invokes]))
+                 [(transient []) (transient {})])
+         first
+         persistent!)))

--- a/cassandra/src/cassandra/collections/map.clj
+++ b/cassandra/src/cassandra/collections/map.clj
@@ -1,0 +1,98 @@
+(ns cassandra.collections.map
+  (:require [clojure.tools.logging :refer [debug info warn]]
+            [jepsen
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]]
+            [knossos.model :as model]
+            [qbits.alia :as alia]
+            [qbits.hayt]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all]
+            [qbits.hayt.utils :refer [map-type]]
+            [cassandra.core :refer :all]
+            [cassandra.conductors :as conductors])
+  (:import (clojure.lang ExceptionInfo)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
+                                                ReadTimeoutException
+                                                WriteTimeoutException
+                                                UnavailableException)))
+
+(defrecord CQLMapClient [tbl-created? conn writec]
+  client/Client
+  (open! [this test _]
+    (let [cluster (alia/cluster {:contact-points (map name (:nodes test))})
+          conn (alia/connect cluster)]
+      (CQLMapClient. tbl-created? conn writec)))
+
+  (setup! [_ test]
+    (locking tbl-created?
+      (when (compare-and-set! tbl-created? false true)
+        (alia/execute conn (create-keyspace :jepsen_keyspace
+                                            (if-exists false)
+                                            (with {:replication {"class"              "SimpleStrategy"
+                                                                 "replication_factor" (:rf test)}})))
+        (alia/execute conn (use-keyspace :jepsen_keyspace))
+        (alia/execute conn (create-table :maps
+                                         (if-exists false)
+                                         (column-definitions {:id          :int
+                                                              :elements    (map-type :int :int)
+                                                              :primary-key [:id]})))
+        (alia/execute conn (alter-table :maps (with {:compaction {:class :SizeTieredCompactionStrategy}})))
+        (alia/execute conn (insert :maps (values [[:id 0]
+                                                  [:elements {}]]))))))
+
+  (invoke! [this test op]
+    (alia/execute conn (use-keyspace :jepsen_keyspace))
+    (try
+      (case (:f op)
+        :add (do (alia/execute conn
+                               (update :maps
+                                       (set-columns {:elements [+ {(:value op) (:value op)}]})
+                                       (where [[= :id 0]]))
+                               {:consistency-level writec})
+                 (assoc op :type :ok))
+        :read (do (wait-for-recovery 30 conn)
+                  (let [value (->> (alia/execute conn
+                                                 (select :maps (where [[= :id 0]]))
+                                                 {:consistency  :all
+                                                  :retry-policy aggressive-read})
+                                   first
+                                   :elements
+                                   vals
+                                   (into (sorted-set)))]
+                    (assoc op :type :ok, :value value))))
+
+      (catch ExceptionInfo e
+        (let [e (class (:exception (ex-data e)))]
+          (condp = e
+            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
+            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
+            UnavailableException (assoc op :type :fail, :error :unavailable)
+            NoHostAvailableException (do
+                                       (info "All the servers are down - waiting 2s")
+                                       (Thread/sleep 2000)
+                                       (assoc op :type :fail, :error :no-host-available)))))))
+
+  (close! [_ _]
+    (info "Closing client with conn" conn)
+    (alia/shutdown conn))
+
+  (teardown! [_ _]))
+
+(defn cql-map-client
+  "A set implemented using CQL maps"
+  ([] (CQLMapClient. (atom false) nil :one))
+  ([writec] (CQLMapClient. (atom false) nil writec)))
+
+(defn map-test
+  [opts]
+  (merge (cassandra-test (str "map-" (:suffix opts))
+                         {:client    (cql-map-client)
+                          :model     (model/set)
+                          :generator (gen/phases
+                                       (->> [(adds)]
+                                            (conductors/std-gen opts))
+                                       (read-once))
+                          :checker   (checker/set)})
+         opts))

--- a/cassandra/src/cassandra/collections/set.clj
+++ b/cassandra/src/cassandra/collections/set.clj
@@ -1,0 +1,100 @@
+(ns cassandra.collections.set
+  (:require [clojure.pprint :refer :all]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]]
+            [knossos.model :as model]
+            [qbits.alia :as alia]
+            [qbits.hayt]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all]
+            [qbits.hayt.utils :refer [set-type]]
+            [cassandra.core :refer :all]
+            [cassandra.conductors :as conductors])
+  (:import (clojure.lang ExceptionInfo)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
+                                                ReadTimeoutException
+                                                WriteTimeoutException
+                                                UnavailableException)))
+
+(defrecord CQLSetClient [tbl-created? conn writec]
+  client/Client
+  (open! [this test _]
+    (let [cluster (alia/cluster {:contact-points (map name (:nodes test))})
+          conn (alia/connect cluster)]
+      (CQLSetClient. tbl-created? conn writec)))
+
+  (setup! [this test]
+    (locking tbl-created?
+      (when (compare-and-set! tbl-created? false true)
+        (alia/execute conn (create-keyspace :jepsen_keyspace
+                                            (if-exists false)
+                                            (with {:replication {"class"              "SimpleStrategy"
+                                                                 "replication_factor" (:rf test)}})))
+        (alia/execute conn (use-keyspace :jepsen_keyspace))
+        (alia/execute conn (create-table :sets
+                                         (if-exists false)
+                                         (column-definitions {:id          :int
+                                                              :elements    (set-type :int)
+                                                              :primary-key [:id]})))
+        (alia/execute conn (alter-table :sets (with {:compaction {:class :SizeTieredCompactionStrategy}})))
+        (alia/execute conn (insert :sets
+                                   (values [[:id 0]
+                                            [:elements #{}]])
+                                   (if-exists false))))))
+
+  (invoke! [this test op]
+    (alia/execute conn (use-keyspace :jepsen_keyspace))
+    (try
+      (case (:f op)
+        :add (do (alia/execute conn
+                               (update :sets
+                                       (set-columns {:elements [+ #{(:value op)}]})
+                                       (where [[= :id 0]]))
+                               {:consistency-level writec})
+                 (assoc op :type :ok))
+        :read (do (wait-for-recovery 30 conn)
+                  (let [value (->> (alia/execute conn
+                                                 (select :sets (where [[= :id 0]]))
+                                                 {:consistency  :all
+                                                  :retry-policy aggressive-read})
+                                   first
+                                   :elements
+                                   (into (sorted-set)))]
+                    (assoc op :type :ok, :value value))))
+
+      (catch ExceptionInfo e
+        (let [e (class (:exception (ex-data e)))]
+          (condp = e
+            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
+            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
+            UnavailableException (assoc op :type :fail, :error :unavailable)
+            NoHostAvailableException (do
+                                       (info "All the servers are down - waiting 2s")
+                                       (Thread/sleep 2000)
+                                       (assoc op :type :fail, :error :no-host-available)))))))
+
+  (close! [_ _]
+    (info "Closing client with conn" conn)
+    (alia/shutdown conn))
+
+  (teardown! [_ _]))
+
+(defn cql-set-client
+  "A set implemented using CQL sets"
+  ([] (CQLSetClient. (atom false) nil :one))
+  ([writec] (CQLSetClient. (atom false) nil writec)))
+
+(defn set-test
+  [opts]
+  (merge (cassandra-test (str "set-" (:suffix opts))
+                         {:client    (cql-set-client)
+                          :model     (model/set)
+                          :generator (gen/phases
+                                       (->> [(adds)]
+                                            (conductors/std-gen opts))
+                                       (read-once))
+                          :checker   (checker/set)})
+         opts))

--- a/cassandra/src/cassandra/conductors.clj
+++ b/cassandra/src/cassandra/conductors.clj
@@ -1,0 +1,114 @@
+(ns cassandra.conductors
+  (:require [cassandra.core :as cassandra]
+            [clojure.set :as set]
+            [clojure.tools.logging :refer :all]
+            [jepsen
+             [control :as c]
+             [generator :as gen]
+             [nemesis :as nemesis]]
+            [jepsen.nemesis.time :as nt]))
+
+(defn bootstrapper
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test] this)
+    (invoke! [this test op]
+      (let [decommissioned (:decommissioned test)]
+        (if-let [node (first @decommissioned)]
+          (do (info node "starting bootstrapping")
+              (swap! decommissioned (comp set rest))
+              (c/on node (cassandra/start! node test))
+              (while (some #{cassandra/dns-resolve (name node)}
+                           (cassandra/joining-nodes test))
+                (info node "still joining")
+                (Thread/sleep 1000))
+              (assoc op :value (str node " bootstrapped")))
+          (assoc op :value "no nodes left to bootstrap"))))
+    (teardown! [this test] this)))
+
+(defn decommissioner
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test] this)
+    (invoke! [this test op]
+      (let [decommissioned (:decommissioned test)]
+        (if-let [node (some-> test
+                              cassandra/live-nodes
+                              (set/difference @decommissioned)
+                              shuffle
+                              (get (:rf test)))] ; keep at least RF nodes
+          (do (info node "decommissioning")
+              (info @decommissioned "already decommissioned")
+              (swap! decommissioned conj node)
+              (cassandra/nodetool node "decommission")
+              (assoc op :value (str node " decommissioned")))
+          (assoc op :value "no nodes eligible for decommission"))))
+    (teardown! [this test] this)))
+
+(defn replayer
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test] this)
+    (invoke! [this test op]
+      (let [live-nodes (cassandra/live-nodes test)]
+        (doseq [node live-nodes]
+          (cassandra/nodetool node "replaybatchlog"))
+        (assoc op :value (str live-nodes " batch logs replayed"))))
+    (teardown! [this test] this)))
+
+(defn flush-and-compacter
+  "Flushes to sstables and forces a major compaction on all nodes"
+  []
+  (reify nemesis/Nemesis
+    (setup! [this test] this)
+    (invoke! [this test op]
+      (case (:f op)
+        :start (do (doseq [node (:nodes test)]
+                     (cassandra/nodetool node "flush")
+                     (cassandra/nodetool node "compact"))
+                   (assoc op :value (str (:nodes test) " nodes flushed and compacted")))
+        :stop (assoc op :value "stop is a no-op with this nemesis")))
+    (teardown! [this test] this)))
+
+(defn mix-failure
+  "Make a seq with start and stop for nemesis failure, and mix bootstrapping and decommissioning"
+  [opts]
+  (let [decop  (when (:decommission (:join opts))
+                 {:type :info :f :decommission})
+        bootop (when (:bootstrap (:join opts))
+                 {:type :info :f :bootstrap})
+        reset  (when (:bump (:clock opts))
+                 (nt/reset-gen opts nil))
+        bump   (when (:bump (:clock opts))
+                 (nt/bump-gen opts nil))
+        strobe (when (:strobe (:clock opts))
+                 (nt/strobe-gen opts nil))
+
+        ops (remove nil? [decop bootop reset bump strobe])
+
+        base [(gen/sleep (+ (rand-int 30) 60))
+              {:type :info :f :start}
+              (gen/sleep (+ (rand-int 30) 60))
+              {:type :info :f :stop}]]
+    (if-let [op (-> ops not-empty rand-nth)]
+      (conj base (gen/sleep (+ (rand-int 30) 60)) op)
+      base)))
+
+(defn mix-failure-seq
+  [opts]
+  (gen/seq (flatten (repeatedly #(mix-failure opts)))))
+
+(defn terminate-nemesis
+  [opts]
+  (if (or (:bump (:clock opts)) (:strobe (:clock opts)))
+    (gen/nemesis (gen/seq [(gen/once {:type :info :f :stop})
+                           (gen/once (nt/reset-gen opts nil))]))
+    (gen/nemesis (gen/once {:type :info :f :stop}))))
+
+(defn std-gen
+  [opts gen]
+  (->> gen
+       gen/mix
+       (gen/nemesis
+         (mix-failure-seq opts))
+       (gen/time-limit (:time-limit opts))))

--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -1,0 +1,324 @@
+(ns cassandra.core
+  (:require [clojure.java.jmx :as jmx]
+            [clojure.set :as set]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen
+             [core :as jepsen]
+             [db :as db]
+             [util :as util :refer [meh timeout]]
+             [control :as c :refer [| lit]]
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [store :as store]
+             [report :as report]
+             [tests :as tests]]
+            [jepsen.checker.timeline :as timeline]
+            [jepsen.control
+             [net :as cn]
+             [util :as cu]]
+            [jepsen.os.debian :as debian]
+            [knossos.core :as knossos]
+            [qbits.alia :as alia]
+            [qbits.hayt]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all])
+  (:import (clojure.lang ExceptionInfo)
+           (com.datastax.driver.core ConsistencyLevel)
+           (com.datastax.driver.core Session)
+           (com.datastax.driver.core Cluster)
+           (com.datastax.driver.core Metadata)
+           (com.datastax.driver.core Host)
+           (com.datastax.driver.core.schemabuilder SchemaBuilder)
+           (com.datastax.driver.core.schemabuilder TableOptions)
+           (com.datastax.driver.core.policies RetryPolicy
+                                              RetryPolicy$RetryDecision)
+           (java.net InetAddress)))
+
+(defn scaled
+  "Applies a scaling factor to a number - used for durations
+  throughout testing to easily scale the run time of the whole
+  test suite. Accepts doubles."
+  [v]
+  (let [factor (or (some-> (System/getenv "JEPSEN_SCALE") (Double/parseDouble))
+                   1)]
+    (Math/ceil (* v factor))))
+
+(defn compaction-strategy
+  "Returns the compaction strategy to use"
+  []
+  (SchemaBuilder/sizedTieredStategy))
+
+(defn compressed-commitlog?
+  "Returns whether to use commitlog compression"
+  []
+  (= (some-> (System/getenv "JEPSEN_COMMITLOG_COMPRESSION") (clojure.string/lower-case))
+     "true"))
+
+(defn coordinator-batchlog-disabled?
+  "Returns whether to disable the coordinator batchlog for MV"
+  []
+  (boolean (System/getenv "JEPSEN_DISABLE_COORDINATOR_BATCHLOG")))
+
+(defn phi-level
+  "Returns the value to use for phi in the failure detector"
+  []
+  (or (System/getenv "JEPSEN_PHI_VALUE")
+      8))
+
+(defn disable-hints?
+  "Returns true if Jepsen tests should run without hints"
+  []
+  (not (System/getenv "JEPSEN_DISABLE_HINTS")))
+
+(defn wait-for-recovery
+  "Waits for the driver to report all nodes are up"
+  [timeout-secs ^Session conn]
+  (timeout (* 1000 timeout-secs)
+           (throw (RuntimeException.
+                    (str "Driver didn't report all nodes were up in "
+                         timeout-secs "s - failing")))
+           (while (->> conn
+                       .getCluster
+                       .getMetadata
+                       .getAllHosts
+                       (map #(.isUp %))
+                       and
+                       not)
+             (Thread/sleep 500))))
+
+(defn dns-resolve
+  "Gets the address of a hostname"
+  [hostname]
+  (.getHostAddress (InetAddress/getByName (name hostname))))
+
+(defn dns-hostnames
+  "Gets the list of hostnames"
+  [test addrs]
+  (let [names (:nodes test)
+        ordered (map dns-resolve names)]
+    (set (map (fn [addr]
+                (->> (.indexOf ordered addr)
+                     (get names)))
+              addrs))))
+
+(defn live-nodes
+  "Get the list of live nodes from a random node in the cluster"
+  [test]
+  (->> (some (fn [node]
+               (try
+                 (jmx/with-connection {:host (name node) :port 7199}
+                                      (jmx/read "org.apache.cassandra.db:type=StorageService"
+                                                :LiveNodes))
+                 (catch Exception e
+                   (info "Couldn't get status from node" node))))
+             (-> test
+                 :nodes
+                 set
+                 (set/difference @(:decommissioned test))
+                 shuffle))
+       (dns-hostnames test)))
+
+(defn joining-nodes
+  "Get the list of joining nodes from a random node in the cluster"
+  [test]
+  (set (mapcat (fn [node]
+                 (try
+                   (jmx/with-connection {:host (name node) :port 7199}
+                                        (jmx/read "org.apache.cassandra.db:type=StorageService"
+                                                  :JoiningNodes))
+                   (catch Exception e
+                     (info "Couldn't get status from node" node))))
+               (-> test
+                   :nodes
+                   set
+                   (set/difference @(:decommissioned test))
+                   shuffle))))
+
+(defn seed-nodes
+  "Get a list of seed nodes"
+  [test]
+  (if (= (:rf test) 1)
+    (take 1 (:nodes test))
+    (take (dec (:rf test)) (:nodes test))))
+
+(defn nodetool
+  "Run a nodetool command"
+  [node & args]
+  (c/on node (apply c/exec (lit "/root/cassandra/bin/nodetool") args)))
+
+; This policy should only be used for final reads! It tries to
+; aggressively get an answer from an unstable cluster after
+; stabilization
+(def aggressive-read
+  (proxy [RetryPolicy] []
+    (onReadTimeout [statement cl requiredResponses
+                    receivedResponses dataRetrieved nbRetry]
+      (if (> nbRetry 100)
+        (RetryPolicy$RetryDecision/rethrow)
+        (RetryPolicy$RetryDecision/retry cl)))
+    (onWriteTimeout [statement cl writeType requiredAcks
+                     receivedAcks nbRetry]
+      (RetryPolicy$RetryDecision/rethrow))
+    (onUnavailable [statement cl requiredReplica aliveReplica nbRetry]
+      (info "Caught UnavailableException in driver - sleeping 2s")
+      (Thread/sleep 2000)
+      (if (> nbRetry 100)
+        (RetryPolicy$RetryDecision/rethrow)
+        (RetryPolicy$RetryDecision/retry cl)))))
+
+(def setup-lock (Object.))
+
+(defn install!
+  "Installs Cassandra on the given node."
+  [node test]
+  (let [url (:tarball test)
+        local-file (second (re-find #"file://(.+)" url))
+        tpath (if local-file "file:///tmp/cassandra.tar.gz" url)]
+    (c/su (debian/install [:openjdk-8-jre]))
+    (info node "installing Cassandra from" url)
+    (do (when local-file
+          (c/upload local-file "/tmp/cassandra.tar.gz"))
+        (cu/install-archive! tpath "/root/cassandra"))))
+
+(defn configure!
+  "Uploads configuration files to the given node."
+  [node test]
+  (info node "configuring Cassandra")
+  (c/su
+    (doseq [rep ["\"s/#MAX_HEAP_SIZE=.*/MAX_HEAP_SIZE='1G'/g\"" ; docker memory should be set to around 8G or more
+                 "\"s/#HEAP_NEWSIZE=.*/HEAP_NEWSIZE='256M'/g\""
+                 "\"s/LOCAL_JMX=yes/LOCAL_JMX=no/g\""
+                 (str "'s/# JVM_OPTS=\"$JVM_OPTS -Djava.rmi.server.hostname="
+                      "<public name>\"/JVM_OPTS=\"$JVM_OPTS -Djava.rmi.server.hostname="
+                      (name node) "\"/g'")
+                 (str "'s/JVM_OPTS=\"$JVM_OPTS -Dcom.sun.management.jmxremote"
+                      ".authenticate=true\"/JVM_OPTS=\"$JVM_OPTS -Dcom.sun.management"
+                      ".jmxremote.authenticate=false\"/g'")
+                 "'/JVM_OPTS=\"$JVM_OPTS -Dcassandra.mv_disable_coordinator_batchlog=.*\"/d'"]]
+      (c/exec :sed :-i (lit rep) "/root/cassandra/conf/cassandra-env.sh"))
+    (doseq [rep (into ["\"s/cluster_name: .*/cluster_name: 'jepsen'/g\""
+                       (str "\"s/seeds: .*/seeds: '"
+                            (clojure.string/join "," (seed-nodes test)) "'/g\"")
+                       (str "\"s/listen_address: .*/listen_address: " (cn/ip node) "/g\"")
+                       (str "\"s/rpc_address: .*/rpc_address: " (cn/ip node) "/g\"")
+                       (str "\"s/hinted_handoff_enabled:.*/hinted_handoff_enabled: " (disable-hints?) "/g\"")
+                       "\"s/commitlog_sync: .*/commitlog_sync: batch/g\""
+                       (str "\"s/# commitlog_sync_batch_window_in_ms: .*/"
+                            "commitlog_sync_batch_window_in_ms: 1.0/g\"")
+                       "\"s/commitlog_sync_period_in_ms: .*/#/g\""
+                       (str "\"s/# phi_convict_threshold: .*/phi_convict_threshold: " (phi-level)
+                            "/g\"")
+                       "\"/auto_bootstrap: .*/d\""]
+                      (when (compressed-commitlog?)
+                        ["\"s/#commitlog_compression.*/commitlog_compression:/g\""
+                         (str "\"s/#   - class_name: LZ4Compressor/"
+                              "    - class_name: LZ4Compressor/g\"")]))]
+      (c/exec :sed :-i (lit rep) "/root/cassandra/conf/cassandra.yaml"))
+    (c/exec :echo (str "JVM_OPTS=\"$JVM_OPTS -Dcassandra.mv_disable_coordinator_batchlog="
+                       (coordinator-batchlog-disabled?) "\"")
+            :>> "/root/cassandra/conf/cassandra-env.sh")
+    (c/exec :sed :-i (lit "\"s/INFO/DEBUG/g\"") "/root/cassandra/conf/logback.xml")))
+
+(defn start!
+  "Starts Cassandra."
+  [node test]
+  (info node "starting Cassandra")
+  (c/su
+    (c/exec (lit "/root/cassandra/bin/cassandra -R"))))
+
+(defn guarded-start!
+  "Guarded start that only starts nodes that have joined the cluster already
+  through initial DB lifecycle or a bootstrap. It will not start decommissioned
+  nodes."
+  [node test]
+  (let [decommissioned (:decommissioned test)]
+    (when-not (@decommissioned node)
+      (start! node test))))
+
+(defn stop!
+  "Stops Cassandra."
+  [node]
+  (info node "stopping Cassandra")
+  (c/su
+    (meh (c/exec :killall :java))
+    (while (.contains (c/exec :ps :-ef) "java")
+      (Thread/sleep 100)))
+  (info node "has stopped Cassandra"))
+
+(defn wipe!
+  "Shuts down Cassandra and wipes data."
+  [node]
+  (stop! node)
+  (info node "deleting data files")
+  (c/su
+    (meh (c/exec :rm :-r "/root/cassandra/logs"))
+    (meh (c/exec :rm :-r "/root/cassandra/data/data"))
+    (meh (c/exec :rm :-r "/root/cassandra/data/hints"))
+    (meh (c/exec :rm :-r "/root/cassandra/data/commitlog"))
+    (meh (c/exec :rm :-r "/root/cassandra/data/saved_caches"))))
+
+(defn wait-turn
+  "A node has to wait because Cassandra node can't start when another node is bootstrapping"
+  [node {:keys [decommissioned nodes]}]
+  (let [indexed-nodes (zipmap nodes (range (count nodes)))
+        idx (indexed-nodes node)]
+    (when-not (@decommissioned node)
+      (Thread/sleep (* 1000 60 idx)))))
+
+(defn db
+  "Cassandra for a particular version."
+  [version]
+  (reify db/DB
+    (setup! [_ test node]
+      (when (seq (System/getenv "LEAVE_CLUSTER_RUNNING"))
+        (wipe! node))
+      (doto node
+        (install! test)
+        (configure! test)
+        (wait-turn test)
+        (guarded-start! test)))
+
+    (teardown! [_ test node]
+      (when-not (seq (System/getenv "LEAVE_CLUSTER_RUNNING"))
+        (wipe! node)))
+
+    db/LogFiles
+    (log-files [db test node]
+      ["/root/cassandra/logs/system.log"])))
+
+(def add {:type :invoke, :f :add, :value 1})
+(def sub {:type :invoke, :f :add, :value -1})
+(def r {:type :invoke, :f :read})
+(defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn cas [_ _] {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]})
+
+(defn adds
+  "Generator that emits :add operations for sequential integers."
+  []
+  (->> (range)
+       (map (fn [x] {:type :invoke, :f :add, :value x}))
+       gen/seq))
+
+(defn assocs
+  "Generator that emits :assoc operations for sequential integers,
+  mapping x to (f x)"
+  [f]
+  (->> (range)
+       (map (fn [x] {:type :invoke :f :assoc :value {:k x
+                                                     :v (f x)}}))
+       gen/seq))
+
+(defn read-once
+  "A generator which reads exactly once."
+  []
+  (gen/clients
+    (gen/once r)))
+
+(defn cassandra-test
+  [name opts]
+  (merge tests/noop-test
+         {:name (str "cassandra-" name)
+          :os   debian/os}
+         opts))

--- a/cassandra/src/cassandra/counter.clj
+++ b/cassandra/src/cassandra/counter.clj
@@ -1,0 +1,93 @@
+(ns cassandra.counter
+  (:require [cassandra.conductors :as conductors]
+            [cassandra.core :refer :all]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen
+             [client :as client]
+             [checker :as checker]]
+            [qbits.alia :as alia]
+            [qbits.hayt]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all])
+  (:import (clojure.lang ExceptionInfo)
+           (com.datastax.driver.core.policies FallthroughRetryPolicy)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
+                                                ReadTimeoutException
+                                                WriteTimeoutException
+                                                UnavailableException)))
+
+(defrecord CQLCounterClient [tbl-created? conn writec]
+  client/Client
+  (open! [this test _]
+    (let [cluster (alia/cluster {:contact-points (map name (:nodes test))})
+          conn (alia/connect cluster)]
+      (CQLCounterClient. tbl-created? conn writec)))
+
+  (setup! [_ test]
+    (locking tbl-created?
+      (when (compare-and-set! tbl-created? false true)
+        (alia/execute conn (create-keyspace :jepsen_keyspace
+                                            (if-exists false)
+                                            (with {:replication {"class"              "SimpleStrategy"
+                                                                 "replication_factor" (:rf test)}})))
+        (alia/execute conn (use-keyspace :jepsen_keyspace))
+        (alia/execute conn (create-table :counters
+                                         (if-exists false)
+                                         (column-definitions {:id          :int
+                                                              :count       :counter
+                                                              :primary-key [:id]})))
+        (alia/execute conn (alter-table :counters (with {:compaction {:class :SizeTieredCompactionStrategy}})))
+        (alia/execute conn (update :counters
+                                   (set-columns :count [+ 0])
+                                   (where [[= :id 0]]))))))
+
+  (invoke! [this test op]
+    (try
+      (alia/execute conn (use-keyspace :jepsen_keyspace))
+      (case (:f op)
+        :add (do (alia/execute conn
+                               (update :counters
+                                       (set-columns :count [+ (:value op)])
+                                       (where [[= :id 0]]))
+                               {:consistency  writec
+                                :retry-policy FallthroughRetryPolicy/INSTANCE})
+                 (assoc op :type :ok))
+        :read (let [value (->> (alia/execute conn
+                                             (select :counters (where [[= :id 0]]))
+                                             {:consistency  :all
+                                              :retry-policy FallthroughRetryPolicy/INSTANCE})
+                               first
+                               :count)]
+                (assoc op :type :ok, :value value)))
+
+      (catch ExceptionInfo e
+        (let [e (class (:exception (ex-data e)))]
+          (condp = e
+            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
+            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
+            UnavailableException (assoc op :type :fail, :error :unavailable)
+            NoHostAvailableException (do
+                                       (info "All the servers are down - waiting 2s")
+                                       (Thread/sleep 2000)
+                                       (assoc op :type :fail, :error :no-host-available)))))))
+
+  (close! [_ _]
+    (info "Closing client with conn" conn)
+    (alia/shutdown conn))
+
+  (teardown! [_ _]))
+
+(defn cql-counter-client
+  "A counter implemented using CQL counters"
+  ([] (CQLCounterClient. (atom false) nil :one))
+  ([writec] (CQLCounterClient. (atom false) nil writec)))
+
+(defn cnt-inc-test
+  [opts]
+  (merge (cassandra-test (str "counter-inc-" (:suffix opts))
+                         {:client    (cql-counter-client)
+                          :checker   (checker/counter)
+                          :generator (->> (repeat 100 add)
+                                          (cons r)
+                                          (conductors/std-gen opts))})
+         opts))

--- a/cassandra/src/cassandra/lwt.clj
+++ b/cassandra/src/cassandra/lwt.clj
@@ -1,0 +1,108 @@
+(ns cassandra.lwt
+  (:require [cassandra.core :refer :all]
+            [cassandra.conductors :as conductors]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen
+             [checker :as checker]
+             [client :as client]
+             [generator :as gen]]
+            [knossos.model :as model]
+            [qbits.alia :as alia]
+            [qbits.hayt]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all])
+  (:import (clojure.lang ExceptionInfo)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
+                                                ReadTimeoutException
+                                                WriteTimeoutException
+                                                UnavailableException)))
+
+(def ak (keyword "[applied]"))  ; this is the name C* returns, define now because
+                                ; it isn't really a valid keyword from reader's
+                                ; perspective
+
+(defrecord CasRegisterClient [tbl-created? conn]
+  client/Client
+  (open! [_ test _]
+    (let [cluster (alia/cluster {:contact-points (map name (:nodes test))})
+          conn (alia/connect cluster)]
+      (CasRegisterClient. tbl-created? conn)))
+
+  (setup! [_ test]
+    (locking tbl-created?
+      (when (compare-and-set! tbl-created? false true)
+        (alia/execute conn (create-keyspace :jepsen_keyspace
+                                            (if-exists false)
+                                            (with {:replication {"class"              "SimpleStrategy"
+                                                                 "replication_factor" (:rf test)}})))
+        (alia/execute conn (use-keyspace :jepsen_keyspace))
+        (alia/execute conn (create-table :lwt
+                                         (if-exists false)
+                                         (column-definitions {:id          :int
+                                                              :value       :int
+                                                              :primary-key [:id]})))
+        (alia/execute conn (alter-table :lwt (with {:compaction {:class :SizeTieredCompactionStrategy}}))))))
+
+  (invoke! [this test op]
+    (alia/execute conn (use-keyspace :jepsen_keyspace))
+    (try
+      (case (:f op)
+        :cas (let [[old new] (:value op)
+                   result (alia/execute conn
+                                        (update :lwt
+                                                (set-columns {:value new})
+                                                (where [[:id 0]])
+                                                (only-if [[:value old]])))]
+               (assoc op :type (if (-> result first ak)
+                                 :ok
+                                 :fail)))
+
+        :write (let [v (:value op)
+                     result (alia/execute conn (update :lwt
+                                                       (set-columns {:value v})
+                                                       (only-if [[:in :value (range 5)]])
+                                                       (where [[= :id 0]])))]
+                 (if (-> result first ak)
+                   (assoc op :type :ok)
+                   (let [result' (alia/execute conn (insert :lwt
+                                                            (values [[:id 0]
+                                                                     [:value v]])
+                                                            (if-exists false)))]
+                     (if (-> result' first ak)
+                       (assoc op :type :ok)
+                       (assoc op :type :fail)))))
+
+        :read (let [v (->> (alia/execute conn
+                                         (select :lwt (where [[= :id 0]]))
+                                         {:consistency :serial})
+                               first
+                               :value)]
+                (assoc op :type :ok, :value v)))
+
+      (catch ExceptionInfo e
+        (let [e (class (:exception (ex-data e)))]
+          (condp = e
+            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
+            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
+            UnavailableException (assoc op :type :fail, :error :unavailable)
+            NoHostAvailableException (do
+                                       (info "All the servers are down - waiting 2s")
+                                       (Thread/sleep 2000)
+                                       (assoc op :type :fail, :error :no-host-available)))))))
+
+  (close! [_ _]
+    (info "Closing client with conn" conn)
+    (alia/shutdown conn))
+
+  (teardown! [_ _]))
+
+(defn lwt-test
+  [opts]
+  (merge (cassandra-test (str "lwt-" (:suffix opts))
+                         {:client    (CasRegisterClient. (atom false) nil)
+                          :checker   (checker/linearizable {:model     (model/cas-register)
+                                                            :algorithm :linear})
+                          :generator (gen/phases
+                                       (->> [r w cas cas cas]
+                                            (conductors/std-gen opts)))})
+         opts))

--- a/cassandra/src/cassandra/nemesis.clj
+++ b/cassandra/src/cassandra/nemesis.clj
@@ -1,0 +1,122 @@
+(ns cassandra.nemesis
+  (:require [clojure.set :as set]
+            [jepsen
+             [control :as c]
+             [nemesis :as nemesis]
+             [util    :as util :refer [meh]]]
+            [cassandra
+             [core       :as cass]
+             [conductors :as conductors]]))
+
+(defn safe-mostly-small-nonempty-subset
+  "Returns a subset of the given collection, with a logarithmically decreasing
+  probability of selecting more elements. Always selects at least one element.
+      (->> #(mostly-small-nonempty-subset [1 2 3 4 5])
+           repeatedly
+           (map count)
+           (take 10000)
+           frequencies
+           sort)
+      ; => ([1 3824] [2 2340] [3 1595] [4 1266] [5 975])"
+  [xs test]
+  (-> xs
+      count
+      inc
+      Math/log
+      rand
+      Math/exp
+      long
+      (take (shuffle xs))
+      set
+      (set/difference @(:decommissioned test))
+      shuffle))
+
+(defn test-aware-node-start-stopper
+  "Takes a targeting function which, given a list of nodes, returns a single
+  node or collection of nodes to affect, and two functions `(start! test node)`
+  invoked on nemesis start, and `(stop! test node)` invoked on nemesis stop.
+  Returns a nemesis which responds to :start and :stop by running the start!
+  and stop! fns on each of the given nodes. During `start!` and `stop!`, binds
+  the `jepsen.control` session to the given node, so you can just call `(c/exec
+  ...)`.
+
+  Re-selects a fresh node (or nodes) for each start--if targeter returns nil,
+  skips the start. The return values from the start and stop fns will become
+  the :values of the returned :info operations from the nemesis, e.g.:
+
+      {:value {:n1 [:killed \"java\"]}}"
+  [targeter start! stop!]
+  (let [nodes (atom nil)]
+    (reify nemesis/Nemesis
+      (setup! [this test] this)
+
+      (invoke! [this test op]
+        (locking nodes
+          (assoc op :type :info, :value
+                 (case (:f op)
+                   :start (if-let [ns (-> test :nodes (targeter test) util/coll)]
+                            (if (compare-and-set! nodes nil ns)
+                              (c/on-many ns (start! test (keyword c/*host*)))
+                              (str "nemesis already disrupting " @nodes))
+                            :no-target)
+                   :stop (if-let [ns @nodes]
+                           (let [all-nodes (:nodes test)
+                                 seed (first (cass/seed-nodes test))
+                                 all-crashed? (= (count ns) (count all-nodes))
+                                 reordered (if all-crashed? (conj (remove #(= seed %) ns) seed) ns)
+                                 restarted (for [node reordered] (c/on node (stop! test node)))]
+                             (reset! nodes nil)
+                             restarted)
+                           :not-started)))))
+
+      (teardown! [this test]
+        (when-let [ns @nodes]
+          (for [node ns] (c/on node (stop! test node)))
+          (reset! nodes nil))))))
+
+(defn crash-nemesis
+  "A nemesis that crashes a random subset of nodes."
+  []
+  (test-aware-node-start-stopper
+   safe-mostly-small-nonempty-subset
+   (fn start [test node] (meh (c/su (c/exec :killall :-9 :java))) [:killed node])
+   (fn stop  [test node]
+     (meh (cass/guarded-start! node test))
+     (Thread/sleep (* 1000 60))
+     [:restarted node])))
+
+;; empty nemesis
+(defn none
+  []
+  {:name "steady"
+   :nemesis nemesis/noop})
+
+(defn flush-and-compacter
+  []
+  {:name "flush"
+   :nemesis (conductors/flush-and-compacter)})
+
+(defn clock-drift
+  []
+  {:name "clock-drift"
+   :nemesis (nemesis/clock-scrambler 10000)})
+
+(defn bridge
+  []
+  {:name "bridge"
+   :nemesis (nemesis/partitioner (comp nemesis/bridge shuffle))})
+
+(defn halves
+  []
+  {:name "halves"
+   :nemesis (nemesis/partition-random-halves)})
+
+(defn isolation
+  []
+  {:name "isolation"
+   :nemesis (nemesis/partition-random-node)})
+
+(defn crash
+  []
+  {:name "crash"
+   :nemesis (crash-nemesis)})

--- a/cassandra/src/cassandra/runner.clj
+++ b/cassandra/src/cassandra/runner.clj
@@ -1,0 +1,116 @@
+(ns cassandra.runner
+  (:gen-class)
+  (:require [cassandra
+             [batch      :as batch]
+             [conductors :as conductors]
+             [core       :as cassandra]
+             [counter    :as counter]
+             [lwt        :as lwt]
+             [nemesis    :as can]]
+            [cassandra.collections.map :as map]
+            [cassandra.collections.set :as set]
+            [jepsen
+             [core    :as jepsen]
+             [cli     :as cli]
+             [nemesis :as jn]]
+            [jepsen.nemesis.time :as nt]))
+
+(def link-to-tarball "http://ftp.meisei-u.ac.jp/mirror/apache/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz")
+;(def link-to-tarball "http://www.us.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz")
+
+(def tests
+  "A map of test names to test constructors."
+  {"batch"   batch/batch-test
+   "map"     map/map-test
+   "set"     set/set-test
+   "counter" counter/cnt-inc-test
+   "lwt"     lwt/lwt-test})
+
+(def nemeses
+  {"none"      `(can/none)
+   "flush"     `(can/flush-and-compacter)
+   "bridge"    `(can/bridge)
+   "halves"    `(can/halves)
+   "isolation" `(can/isolation)
+   "crash"     `(can/crash)})
+
+(def joinings
+  {"none"         {:name ""                 :bootstrap false :decommission false}
+   "bootstrap"    {:name "-bootstrap"       :bootstrap true  :decommission false}
+   "decommission" {:name "-decommissioning" :bootstrap false :decommission true}
+   "rejoin"       {:name "-rejoining"       :bootstrap true  :decommission true}})
+
+(def clocks
+  {"none"   {:name ""              :bump false :strobe false}
+   "bump"   {:name "-clock-bump"   :bump true  :strobe false}
+   "strobe" {:name "-clock-strobe" :bump false :strobe true}
+   "drift"  {:name "-clock-drift"  :bump true  :strobe true}})
+
+(def opt-spec
+  [(cli/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)
+
+   (cli/repeated-opt nil "--nemesis NAME" "Which nemeses to use"
+                     [`(can/none)]
+                     nemeses)
+
+   (cli/repeated-opt nil "--join NAME" "Which node joinings to use"
+                     [{:name "" :bootstrap false :decommission false}]
+                     joinings)
+
+   (cli/repeated-opt nil "--clock NAME" "Which clock-drift to use"
+                     [{:name "" :bump false :strobe false}]
+                     clocks)
+
+   [nil "--rf REPLICATION_FACTOR" "Replication factor"
+    :default 3
+    :parse-fn #(Long/parseLong %)
+    :validate [pos? "Must be positive"]]
+
+   (cli/tarball-opt link-to-tarball)])
+
+(defn combine-nemesis
+  "Combine nemesis options with bootstrapper and decommissioner"
+  [opts nemesis joining clock]
+  (-> opts
+      (assoc :suffix (str (:name (eval nemesis)) (:name joining) (:name clock)))
+      (assoc :join joining)
+      (assoc :clock clock)
+      (assoc :decommissioned
+             (if (:bootstrap joining)
+               (atom #{(last (:nodes opts))})
+               (atom #{})))
+      (assoc :nemesis
+             (jn/compose
+               (conj {#{:start :stop} (:nemesis (eval nemesis))}
+                     (when (:decommission joining)
+                       {#{:decommission} (conductors/decommissioner)})
+                     (when (:bootstrap joining)
+                       {#{:bootstrap} (conductors/bootstrapper)})
+                     (when (or (:bump clock) (:strobe clock))
+                       {#{:reset :bump :strobe} (nt/clock-nemesis)}))))))
+
+(defn test-cmd
+   []
+   {"test" {:opt-spec (into cli/test-opt-spec opt-spec)
+            :opt-fn (fn [parsed] (-> parsed cli/test-opt-fn))
+            :usage (cli/test-usage)
+            :run (fn [{:keys [options]}]
+                   (doseq [i        (range (:test-count options))
+                           test-fn  (:test options)
+                           nemesis  (:nemesis options)
+                           joining  (:join options)
+                           clock    (:clock options)]
+                     (let [test (-> options
+                                    (combine-nemesis nemesis joining clock)
+                                    (assoc :db (cassandra/db (:cassandra options)))
+                                    (dissoc :test)
+                                    test-fn
+                                    jepsen/run!)]
+                       (when-not (:valid? (:results test))
+                         (System/exit 1)))))}})
+
+(defn -main
+  [& args]
+  (cli/run! (merge (cli/serve-cmd)
+                   (test-cmd))
+            args))

--- a/cassandra/test/cassandra/cassandra_test.clj
+++ b/cassandra/test/cassandra/cassandra_test.clj
@@ -1,0 +1,69 @@
+(ns cassandra.cassandra-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as string]
+            [jepsen.core :as jepsen]
+            [cassandra.collections.map :as map]
+            [cassandra.collections.set :as set]
+            [cassandra
+             [core    :as cassandra]
+             [batch   :as batch]
+             [counter :as counter]
+             [lwt     :as lwt]
+             [nemesis :as can]
+             [runner  :as runner]]))
+
+(def nodes ["n1" "n2" "n3" "n4" "n5"])
+
+(defn check
+  [test-fn nemesis joining clock]
+  (-> {:nodes nodes :rf 3 :db (cassandra/db "3.11.3") :concurrency 5 :time-limit 60}
+      (runner/combine-nemesis nemesis joining clock)
+      test-fn
+      jepsen/run!
+      :results
+      :valid?
+      is))
+
+(defmacro add-nemesis
+  [name suffix test-fn joining clock]
+  `(do
+     (deftest ~(symbol (str name "-steady"      suffix))
+              (check ~test-fn `(can/none)                ~joining ~clock))
+     (deftest ~(symbol (str name "-flush"       suffix))
+              (check ~test-fn `(can/flush-and-compacter) ~joining ~clock))
+     (deftest ~(symbol (str name "-bridge"      suffix))
+              (check ~test-fn `(can/bridge)              ~joining ~clock))
+     (deftest ~(symbol (str name "-halves"      suffix))
+              (check ~test-fn `(can/halves)              ~joining ~clock))
+     (deftest ~(symbol (str name "-isolation"   suffix))
+              (check ~test-fn `(can/isolation)           ~joining ~clock))
+     (deftest ~(symbol (str name "-crash"       suffix))
+              (check ~test-fn `(can/crash)               ~joining ~clock))))
+
+(defmacro add-joining
+  [name suffix test-fn clock]
+    `(do
+       (add-nemesis ~name ~(str ""                 suffix) ~test-fn
+                    {:name ""                 :bootstrap false :decommission false} ~clock)
+       (add-nemesis ~name ~(str "-bootstrap"       suffix) ~test-fn
+                    {:name "-bootstrap"       :bootstrap true  :decommission false} ~clock)
+       (add-nemesis ~name ~(str "-decommissioning" suffix) ~test-fn
+                    {:name "-decommissioning" :bootstrap false :decommission true}  ~clock)
+       (add-nemesis ~name ~(str "-rejoining"       suffix) ~test-fn
+                    {:name "-rejoining"       :bootstrap true  :decommission true}  ~clock)))
+
+(defmacro def-tests
+  [test-fn]
+  (let [name# (-> test-fn name (string/replace "-test" ""))]
+    `(do
+       (add-joining name# ""              ~test-fn {:name ""              :bump false :strobe false})
+       (add-joining name# "-clock-bump"   ~test-fn {:name "-clock-bump"   :bump true  :strobe false})
+       (add-joining name# "-clock-strobe" ~test-fn {:name "-clock-strobe" :bump false :strobe true})
+       (add-joining name# "-clock-drift"  ~test-fn {:name "-clock-drift"  :bump true  :strobe true}))))
+
+
+(def-tests batch/batch-test)
+(def-tests map/map-test)
+(def-tests set/set-test)
+(def-tests counter/cnt-inc-test)
+(def-tests lwt/lwt-test)

--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -1,0 +1,59 @@
+# Jepsen tests for Scalar DB
+
+This guide will teach you how to run Jepsen tests for Scalar DB.
+The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar-labs/jepsen/tree/cassandra).
+
+## How to run tests
+
+1. Get Jepsen which has Cassandra tests
+
+    ```
+    $ git clone -b cassandra https://github.com/scalar-labs/jepsen.git
+    ```
+
+2. Copy this directory to your Jepsen directory
+
+    ```
+    $ cp -r ${SCALAR_DB_HOME}/jepsen/scalardb ${JEPSEN}/
+    ```
+
+3. Start Jepsen with docker
+
+    - The script starts 5 nodes and a control node (jepsen-control)
+
+    ```
+    $ cd ${JEPSEN}/docker
+    $ ./up.sh
+    ```
+
+    - Login to jepsen-control
+
+    ```
+    $ docker exec -it jepsen-control bash
+    ```
+
+4. Install the Cassandra test tool
+
+    ```
+    # in jepsen-control
+    
+    $ cd /jepsen/cassandra
+    $ lein install
+    ```
+
+    Or, you can add the following line after `RUN cd /jepsen/jepsen && lein install` to `${JEPSEN}/docker/control/Dockerfile`
+
+    ```
+    RUN cd /jepsen/cassandra && lein install
+    ```
+
+5. Run a test of Scalar DB
+
+    ```
+    # in jepsen-control
+
+    $ cd /jepsen/scalardb
+    $ lein run test --test transfer --nemesis crash --join decommission --time-limit 300
+    ```
+
+    Use `lein run test --help` to see a list of the full options

--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -4,7 +4,9 @@ This guide will teach you how to run Jepsen tests for Scalar DB.
 The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar-labs/scalar-jepsen/tree/cassandra).
 
 ## How to test
-1. Install the Cassandra test tool
+1. Start the Docker nodes or multiple machines and log into jepsen-control (as explained [here](https://github.com/scalar-labs/scalar-jepsen/tree/README.md)).
+
+2. Install the Cassandra test tool
 
     ```
     # in jepsen-control
@@ -13,7 +15,7 @@ The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar
     $ lein install
     ```
 
-2. Run a test of Scalar DB
+3. Run a test of Scalar DB
 
     ```
     # in jepsen-control

--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -1,59 +1,25 @@
 # Jepsen tests for Scalar DB
 
 This guide will teach you how to run Jepsen tests for Scalar DB.
-The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar-labs/jepsen/tree/cassandra).
+The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar-labs/scalar-jepsen/tree/cassandra).
 
-## How to run tests
-
-1. Get Jepsen which has Cassandra tests
-
-    ```
-    $ git clone -b cassandra https://github.com/scalar-labs/jepsen.git
-    ```
-
-2. Copy this directory to your Jepsen directory
-
-    ```
-    $ cp -r ${SCALAR_DB_HOME}/jepsen/scalardb ${JEPSEN}/
-    ```
-
-3. Start Jepsen with docker
-
-    - The script starts 5 nodes and a control node (jepsen-control)
-
-    ```
-    $ cd ${JEPSEN}/docker
-    $ ./up.sh
-    ```
-
-    - Login to jepsen-control
-
-    ```
-    $ docker exec -it jepsen-control bash
-    ```
-
-4. Install the Cassandra test tool
+## How to test
+1. Install the Cassandra test tool
 
     ```
     # in jepsen-control
-    
-    $ cd /jepsen/cassandra
+
+    $ cd ${SCALAR_JEPSEN}/cassandra
     $ lein install
     ```
 
-    Or, you can add the following line after `RUN cd /jepsen/jepsen && lein install` to `${JEPSEN}/docker/control/Dockerfile`
-
-    ```
-    RUN cd /jepsen/cassandra && lein install
-    ```
-
-5. Run a test of Scalar DB
+2. Run a test of Scalar DB
 
     ```
     # in jepsen-control
 
-    $ cd /jepsen/scalardb
+    $ cd ${SCALAR_JEPSEN}/scalardb
     $ lein run test --test transfer --nemesis crash --join decommission --time-limit 300
     ```
 
-    Use `lein run test --help` to see a list of the full options
+  - See `lein run test --help` for full options

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -1,0 +1,13 @@
+(defproject scalardb "0.1.0-SNAPSHOT"
+  :description "Jepsen testing for Scalar DB"
+  :url "https://github.com/scalar-labs/scalardb"
+  :license {:name ""
+            :url ""}
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [jepsen "0.1.13"]
+                 [cassandra "0.1.0-SNAPSHOT"]
+                 [cc.qbits/alia "4.3.1"]
+                 [cc.qbits/hayt "4.1.0"]
+                 [com.scalar-labs/scalardb "1.0.0" :exclusions [org.slf4j/slf4j-log4j12]]]
+  :main scalardb.runner
+  :aot [scalardb.runner])

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -1,0 +1,165 @@
+(ns scalardb.core
+  (:require [cassandra.core :as c]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen.tests :as tests]
+            [qbits.alia :as alia]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all])
+  (:import (com.scalar.database.api TransactionState)
+           (com.scalar.database.config DatabaseConfig)
+           (com.scalar.database.storage.cassandra Cassandra)
+           (com.scalar.database.service StorageModule
+                                        StorageService
+                                        TransactionModule
+                                        TransactionService)
+           (com.scalar.database.transaction.consensuscommit Coordinator)
+           (com.google.inject Guice)
+           (java.util Properties)))
+
+(def ^:const RETRIES 8)
+(def ^:const RETRIES_FOR_RECONNECTION 3)
+
+(def ^:const COORDINATOR "coordinator")
+(def ^:const STATE_TABLE "state")
+(def ^:const VERSION "tx_version")
+
+(defn exponential-backoff
+  [r]
+  (Thread/sleep (reduce * 1000 (repeat r 2))))
+
+(defn create-coordinator-table!
+  [session test]
+  (alia/execute session (create-keyspace COORDINATOR
+                                         (if-exists false)
+                                         (with {:replication {"class"              "SimpleStrategy"
+                                                              "replication_factor" (:rf test)}})))
+  (alia/execute session (use-keyspace COORDINATOR))
+  (alia/execute session (create-table STATE_TABLE
+                                      (if-exists false)
+                                      (column-definitions {:tx_id         :text
+                                                           :tx_state      :int
+                                                           :tx_created_at :bigint
+                                                           :primary-key   [:tx_id]}))))
+
+(defn- create-properties
+  [nodes]
+  (let [props (Properties.)]
+    (if (= (count nodes) 1)
+      (.setProperty props
+                    "scalar.database.contact_points"
+                    (first nodes))
+      (.setProperty props
+                    "scalar.database.contact_points"
+                    (reduce #(str %1 "," %2) nodes)))
+    (.setProperty props "scalar.database.username" "cassandra")
+    (.setProperty props "scalar.database.password" "cassandra")
+    props))
+
+(defn- close-storage!
+  [test]
+  (let [storage (:storage test)]
+    (locking storage
+      (when-not (nil? @storage)
+        (.close @storage)
+        (reset! storage nil)
+        (info "The current storage service closed")))))
+
+(defn- close-transaction!
+  [test]
+  (let [transaction (:transaction test)]
+    (locking transaction
+      (when-not (nil? @transaction)
+        (.close @transaction)
+        (reset! transaction nil)
+        (info "The current transaction service closed")))))
+
+(defn close-all!
+  [test]
+  (close-storage! test)
+  (close-transaction! test))
+
+(defn prepare-storage-service!
+  [test]
+  (close-storage! test)
+  (info "reconnecting to the cluster")
+  (loop [tries RETRIES]
+    (when (< tries RETRIES)
+      (exponential-backoff (- RETRIES tries)))
+    (if-not (pos? tries)
+      (warn "Failed to connect to the cluster")
+      (if-let [injector (some->> (c/live-nodes test)
+                                 not-empty
+                                 create-properties
+                                 DatabaseConfig.
+                                 StorageModule.
+                                 vector
+                                 Guice/createInjector)]
+        (try
+          (->> (.getInstance injector StorageService)
+               (reset! (:storage test)))
+          (catch Exception e
+            (warn (.getMessage e))))
+        (when-not (nil? (:storage test))
+          (recur (dec tries)))))))
+
+(defn prepare-transaction-service!
+  [test]
+  (close-transaction! test)
+  (info "reconnecting to the cluster")
+  (loop [tries RETRIES]
+    (when (< tries RETRIES)
+      (exponential-backoff (- RETRIES tries)))
+    (if-not (pos? tries)
+      (warn "Failed to connect to the cluster")
+      (if-let [injector (some->> (c/live-nodes test)
+                                 not-empty
+                                 create-properties
+                                 DatabaseConfig.
+                                 TransactionModule.
+                                 vector
+                                 Guice/createInjector)]
+        (try
+          (->> (.getInstance injector TransactionService)
+               (reset! (:transaction test)))
+          (catch Exception e
+            (warn (.getMessage e))))
+        (when-not (nil? (:transaction test))
+          (recur (dec tries)))))))
+
+(defn start-transaction
+  [test]
+  (some-> test :transaction deref .start))
+
+(defn- is-committed-state?
+  "Return true if the status is COMMITTED. Return nil if the read fails."
+  [coordinator id]
+  (try
+      (let [state (.getState coordinator id)]
+        (and (.isPresent state)
+             (-> state .get .getState (.equals TransactionState/COMMITTED))))
+      (catch Exception e nil)))
+
+(defn check-transaction-states
+  "Return the number of COMMITTED states by checking the coordinator. Return nil if it fails."
+  [test ids]
+  (loop [tries RETRIES]
+    (if-not (pos? tries)
+      nil
+      (do
+        (when (< tries RETRIES)
+          (exponential-backoff (- RETRIES tries)))
+        (when (zero? (mod tries RETRIES_FOR_RECONNECTION))
+          (prepare-storage-service! test)) ; reconnection
+        (let [coordinator (Coordinator. (deref (:storage test)))
+              committed   (map (partial is-committed-state? coordinator) ids)]
+          (if-not (some nil? committed)
+            (->> committed (filter true?) count)
+            (recur (dec tries))))))))
+
+(defn scalardb-test
+  [name opts]
+  (merge tests/noop-test
+         {:name        (str "scalardb-" name)
+          :storage     (atom nil)
+          :transaction (atom nil)}
+         opts))

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -1,0 +1,63 @@
+(ns scalardb.runner
+  (:gen-class)
+  (:require [cassandra
+             [core :as cassandra]
+             [runner :as car]
+             [nemesis :as can]]
+            [jepsen
+             [core :as jepsen]
+             [cli :as cli]]
+            [scalardb.transfer]
+            [scalardb.transfer_append]))
+
+(def tests
+  "A map of test names to test constructors."
+  {"transfer"        scalardb.transfer/transfer-test
+   "transfer-append" scalardb.transfer_append/transfer-append-test})
+
+(def opt-spec
+  [(cli/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)
+
+   (cli/repeated-opt nil "--nemesis NAME" "Which nemeses to use"
+                     [`(can/none)]
+                     car/nemeses)
+
+   (cli/repeated-opt nil "--join NAME" "Which node joinings to use"
+                     [{:name "" :bootstrap false :decommission false}]
+                     car/joinings)
+
+   (cli/repeated-opt nil "--clock NAME" "Which clock-drift to use"
+                     [{:name "" :bump false :strobe false}]
+                     car/clocks)
+
+   [nil "--rf REPLICATION_FACTOR" "Replication factor"
+    :default 3
+    :parse-fn #(Long/parseLong %)
+    :validate [pos? "Must be positive"]]
+
+   (cli/tarball-opt "https://archive.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz")])
+
+(defn test-cmd
+   []
+   {"test" {:opt-spec (into cli/test-opt-spec opt-spec)
+            :opt-fn   (fn [parsed] (-> parsed cli/test-opt-fn))
+            :usage    (cli/test-usage)
+            :run      (fn [{:keys [options]}]
+                        (doseq [i (range (:test-count options))
+                                test-fn (:test options)
+                                nemesis (:nemesis options)
+                                joining (:join options)
+                                clock (:clock options)]
+                          (let [test (-> options
+                                         (car/combine-nemesis nemesis joining clock)
+                                         (assoc :db (cassandra/db (:cassandra options)))
+                                         (dissoc :test)
+                                         test-fn
+                                         jepsen/run!)]
+                            (when-not (:valid? (:results test))
+                              (System/exit 1)))))}})
+
+(defn -main
+  [& args]
+  (cli/run! (test-cmd)
+            args))

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -1,0 +1,304 @@
+(ns scalardb.transfer
+  (:require [cassandra
+             [core :as c]
+             [conductors :as conductors]]
+            [clojure.tools.logging :refer [debug info warn]]
+            [clojure.core.reducers :as r]
+            [jepsen
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]]
+            [knossos.op :as op]
+            [qbits.alia :as alia]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all]
+            [scalardb.core :as scalar])
+  (:import (com.scalar.database.api Consistency
+                                    DistributedStorage
+                                    DistributedTransaction
+                                    Get
+                                    Isolation
+                                    Put
+                                    Result)
+           (com.scalar.database.io IntValue
+                                   Key)
+           (com.scalar.database.exception.transaction CommitException
+                                                      CrudException
+                                                      UnknownTransactionStatusException)))
+
+(def ^:const KEYSPACE "jepsen")
+(def ^:const TABLE "transfer")
+(def ^:const ACCOUNT_ID "account_id")
+(def ^:const BALANCE "balance")
+
+(def ^:const INITIAL_BALANCE 10000)
+(def ^:const NUM_ACCOUNTS 10)
+(def ^:const total-balance (* NUM_ACCOUNTS INITIAL_BALANCE))
+
+(def ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
+
+(defn- create-transfer-table!
+  [session test]
+  (alia/execute session (create-keyspace KEYSPACE
+                                         (if-exists false)
+                                         (with {:replication {"class"              "SimpleStrategy"
+                                                              "replication_factor" (:rf test)}})))
+  (alia/execute session (use-keyspace KEYSPACE))
+  (alia/execute session (create-table TABLE
+                                      (if-not-exists)
+                                      (column-definitions {:account_id             :int
+                                                           :balance                :int
+                                                           :tx_id                  :text
+                                                           :tx_version             :int
+                                                           :tx_state               :int
+                                                           :tx_prepared_at         :bigint
+                                                           :tx_committed_at        :bigint
+                                                           :before_account_id      :int
+                                                           :before_balance         :int
+                                                           :before_tx_id           :text
+                                                           :before_tx_version      :int
+                                                           :before_tx_state        :int
+                                                           :before_tx_prepared_at  :bigint
+                                                           :before_tx_committed_at :bigint
+                                                           :primary-key            [:account_id]})))
+  (alia/execute session (alter-table TABLE
+                                     (with {:compaction {:class :SizeTieredCompactionStrategy}}))))
+
+(defn prepare-get
+  [id]
+  (-> (Key. [(IntValue. ACCOUNT_ID id)])
+      (Get.)
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withConsistency Consistency/LINEARIZABLE)))
+
+(defn prepare-put
+  [id v]
+  (-> (Key. [(IntValue. ACCOUNT_ID id)])
+      (Put.)
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withValue v)
+      (.withConsistency Consistency/LINEARIZABLE)))
+
+(defn populate-accounts
+  "Insert initial records with transaction.
+  This method assumes that n is small (< 100)"
+  [test n balance]
+  (let [tx (scalar/start-transaction test)]
+    (try
+      (dotimes [i n]
+        (->>
+          (prepare-put i (IntValue. BALANCE balance))
+          (.put tx)))
+      (.commit tx)
+      (catch Exception e
+        (throw (RuntimeException. (.getMessage e)))))))
+
+(defn calc-new-val
+  "Calculate the new value from the result of transaction.get()"
+  [r amount]
+  (IntValue. BALANCE
+             (-> r .get (.getValue BALANCE) .get .get (+ amount))))
+
+(defn tx-transfer
+  [tx from to amount]
+  (let [fromResult (.get tx (prepare-get from))
+        toResult (.get tx (prepare-get to))]
+    (->> (calc-new-val fromResult (- amount))
+         (prepare-put from)
+         (.put tx))
+    (->> (calc-new-val toResult amount)
+         (prepare-put to)
+         (.put tx))
+    (.commit tx)))
+
+(defn read-record
+  "Read a record with a transaction. If read fails, this function returns nil."
+  [tx i]
+  (try
+    (.get tx (prepare-get i))
+    (catch CrudException e nil)))
+
+(defn read-all-records
+  "Read records from 0 .. (n - 1)"
+  [test n]
+  (let [tx (scalar/start-transaction test)]
+    (map #(read-record tx %) (range n))))
+
+(defn read-all-with-retry
+  "Read records from 0 .. (n - 1) and retry if needed"
+  [test n]
+  (when (nil? (deref (:transaction test)))
+    (scalar/prepare-transaction-service! test))
+  (loop [tries scalar/RETRIES]
+    (when (< tries scalar/RETRIES)
+      (scalar/exponential-backoff (- scalar/RETRIES tries)))
+    (when (zero? (mod tries scalar/RETRIES_FOR_RECONNECTION))
+      (scalar/prepare-transaction-service! test))
+    (let [results (read-all-records test n)]
+      (if (empty? (filter nil? results))
+        results
+        (if (pos? tries)
+          (recur (dec tries))
+          (throw (ex-info "Failed to read all records"
+                          {:cause "Failed to read all records"})))))))
+
+(defn get-balance
+  "Get a balance from a result"
+  [r]
+  (-> r .get (.getValue BALANCE) .get .get))
+
+(defn get-version
+  "Get a version from a result"
+  [r]
+  (-> r .get (.getValue scalar/VERSION) .get .get))
+
+(defn get-balances-and-versions
+  "Read all records with a transaction. Return only balances and versions."
+  [test n]
+  (let [results (read-all-with-retry test n)]
+    (map #(assoc {} :balance (get-balance %) :version (get-version %)) results)))
+
+(defn- try-reconnection!
+  [test]
+  (when (= (swap! (:failures test) inc) NUM_FAILURES_FOR_RECONNECTION)
+    (scalar/prepare-transaction-service! test)
+    (reset! (:failures test) 0)))
+
+(defrecord TransferClient [initialized? n initial-balance]
+  client/Client
+  (open! [_ _ _]
+    (TransferClient. initialized? n initial-balance))
+
+  (setup! [_ test]
+    (locking initialized?
+      (when (compare-and-set! initialized? false true)
+        (let [session (alia/connect
+                        (alia/cluster {:contact-points (->> test :nodes (map name))}))]
+          (create-transfer-table! session test)
+          (scalar/create-coordinator-table! session test)
+          (alia/shutdown session))
+        (scalar/prepare-storage-service! test)
+        (scalar/prepare-transaction-service! test)
+        (populate-accounts test n initial-balance))))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :transfer (if-let [tx (scalar/start-transaction test)]
+                  (try
+                    (tx-transfer tx (-> op :value :from) (-> op :value :to) (-> op :value :amount))
+                    (assoc op :type :ok)
+                    (catch UnknownTransactionStatusException e
+                      (swap! (:unknown-tx test) conj (.getId tx))
+                      (assoc op :type :fail :error {:unknown-tx-status (.getId tx)}))
+                    (catch Exception e
+                      (try-reconnection! test)
+                      (assoc op :type :fail :error (.getMessage e))))
+                  (do
+                    (try-reconnection! test)
+                    (assoc op :type :fail :error "Skipped due to no connection")))
+      :get-all (if-let [results (get-balances-and-versions test (:num op))]
+                 (assoc op :type :ok :value results)
+                 (assoc op :type :fail :error "Failed to get balances"))
+      :check-tx (let [unknown (:unknown-tx test)]
+                  (if-let [num-committed (if (empty? @unknown)
+                                           0
+                                           (scalar/check-transaction-states test @unknown))]
+                    (assoc op :type :ok :value num-committed)
+                    (assoc op :type :fail :error "Failed to check status")))))
+
+  (close! [_ _])
+
+  (teardown! [_ test]
+    (scalar/close-all! test)))
+
+(defn transfer
+  [test _]
+  (let [n (-> test :model :num)]
+    {:type  :invoke
+     :f     :transfer
+     :value {:from   (rand-int n)
+             :to     (rand-int n)
+             :amount (+ 1 (rand-int 1000))}}))
+
+(def diff-transfer
+  (gen/filter (fn [op] (not= (-> op :value :from)
+                             (-> op :value :to)))
+              transfer))
+
+(defn get-all
+  [test _]
+  {:type :invoke
+   :f    :get-all
+   :num  (-> test :model :num)})
+
+(defn check-tx
+  [test _]
+  {:type :invoke
+   :f    :check-tx})
+
+(defn consistency-checker
+  []
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [read-result (->> history
+                             (r/filter op/ok?)
+                             (r/filter #(= :get-all (:f %)))
+                             (r/filter identity)
+                             (into [])
+                             last
+                             :value)
+            actual-balance (->> read-result
+                                (map :balance)
+                                (reduce +))
+            bad-balance (if-not (= actual-balance total-balance)
+                          {:type     :wrong-balance
+                           :expected total-balance
+                           :actual   actual-balance})
+            actual-version (->> read-result
+                                (map :version)
+                                (reduce +))
+            checked-committed (->> history
+                                   (r/filter #(= :check-tx (:f %)))
+                                   (r/filter identity)
+                                   (into [])
+                                   last
+                                   ((fn [x]
+                                      (if (= (:type x) :ok) (:value x) 0))))
+            total-ok (->> history
+                          (r/filter op/ok?)
+                          (r/filter #(= :transfer (:f %)))
+                          (r/filter identity)
+                          (into [])
+                          count
+                          (+ checked-committed))
+            expected-version (-> total-ok
+                                 (* 2)                       ; update 2 records per a transfer
+                                 (+ (-> test :model :num)))  ; initial insertions
+            bad-version (if-not (= actual-version expected-version)
+                          {:type     :wrong-version
+                           :expected expected-version
+                           :actual   actual-version})]
+        {:valid?               (and (empty? bad-balance) (empty? bad-version))
+         :total-version        actual-version
+         :committed-unknown-tx checked-committed
+         :bad-balance          bad-balance
+         :bad-version          bad-version}))))
+
+(defn transfer-test
+  [opts]
+  (merge (scalar/scalardb-test (str "transfer-" (:suffix opts))
+                               {:client     (TransferClient. (atom false) NUM_ACCOUNTS INITIAL_BALANCE)
+                                :model      {:num NUM_ACCOUNTS}
+                                :unknown-tx (atom #{})
+                                :failures   (atom 0)
+                                :generator  (gen/phases
+                                              (->> [diff-transfer]
+                                                   (conductors/std-gen opts))
+                                              (conductors/terminate-nemesis opts)
+                                              (gen/clients (gen/once check-tx))
+                                              (gen/clients (gen/once get-all)))
+                                :checker    (checker/compose
+                                              {:details (consistency-checker)})})
+         opts))

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -1,0 +1,318 @@
+(ns scalardb.transfer_append
+  (:require [cassandra.conductors :as conductors]
+            [clojure.tools.logging :refer [debug info warn]]
+            [clojure.core.reducers :as r]
+            [jepsen
+             [client :as client]
+             [checker :as checker]
+             [generator :as gen]]
+            [knossos.op :as op]
+            [qbits.alia :as alia]
+            [qbits.hayt.dsl.clause :refer :all]
+            [qbits.hayt.dsl.statement :refer :all]
+            [scalardb.core :as scalar])
+  (:import (com.scalar.database.api Put
+                                    Scan
+                                    Scan$Ordering
+                                    Scan$Ordering$Order
+                                    Result)
+           (com.scalar.database.exception.transaction CrudException
+                                                      UnknownTransactionStatusException)
+           (com.scalar.database.io IntValue
+                                   Key)))
+
+(def ^:const KEYSPACE "jepsen_keyspace")
+(def ^:const TABLE "transfer")
+(def ^:const ACCOUNT_ID "account_id")
+(def ^:const BALANCE "balance")
+(def ^:const AGE "age")
+(def ^:const INITIAL_BALANCE 10000)
+(def ^:const NUM_ACCOUNTS 10)
+(def ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
+(def ^:const total-balance (* NUM_ACCOUNTS INITIAL_BALANCE))
+
+(defn- create-transfer-table!
+  [session test]
+  (alia/execute session (create-keyspace KEYSPACE
+                                         (if-exists false)
+                                         (with {:replication {"class"              "SimpleStrategy"
+                                                              "replication_factor" (:rf test)}})))
+  (alia/execute session (use-keyspace KEYSPACE))
+  (alia/execute session (create-table TABLE
+                                      (if-exists false)
+                                      (column-definitions {:account_id             :int
+                                                           :age                    :int
+                                                           :balance                :int
+                                                           :tx_id                  :text
+                                                           :tx_prepared_at         :bigint
+                                                           :tx_committed_at        :bigint
+                                                           :tx_state               :int
+                                                           :tx_version             :int
+                                                           :before_balance         :int
+                                                           :before_tx_committed_at :bigint
+                                                           :before_tx_id           :text
+                                                           :before_tx_prepared_at  :bigint
+                                                           :before_tx_state        :int
+                                                           :before_tx_version      :int
+                                                           :primary-key            [:account_id :age]})))
+  (alia/execute session (alter-table TABLE
+                                     (with {:compaction {:class :SizeTieredCompactionStrategy}}))))
+
+(defn prepare-scan
+  [id]
+  (-> (Key. [(IntValue. ACCOUNT_ID id)])
+      (Scan.)
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withOrdering (Scan$Ordering. "age" Scan$Ordering$Order/DESC))))
+
+(defn prepare-scan-with-limit
+  [id limit]
+  (-> id
+      (prepare-scan)
+      (.withLimit limit)))
+
+(defn scan-and-return-first-result
+  [tx scan]
+  (first (.scan tx scan)))
+
+(defn prepare-put
+  [id age balance]
+  (-> (Put. (Key. [(IntValue. ACCOUNT_ID id)]) (Key. [(IntValue. AGE age)]))
+      (.forNamespace KEYSPACE)
+      (.forTable TABLE)
+      (.withValue (IntValue. BALANCE balance))))
+
+(defn populate-accounts
+  "Insert initial records with transaction.
+  This method assumes that n is small (< 100)"
+  [test n balance]
+  (let [tx (scalar/start-transaction test)]
+    (try
+      (dotimes [i n]
+        (->>
+          (prepare-put i 1 balance)
+          (.put tx)))
+      (.commit tx)
+      (catch Exception e
+        (throw (RuntimeException. (.getMessage e)))))))
+
+(defn calc-new-balance
+  "Calculate the new value from the result of transaction.get()"
+  [^Result result amount]
+  (-> result (.getValue BALANCE) .get .get (+ amount)))
+
+(defn calc-new-age
+  "Calculate the new value from the result of transaction.get()"
+  [^Result result]
+  (-> result (.getValue AGE) .get .get inc))
+
+(defn tx-transfer
+  [tx from to amount]
+  (let [^Result fromResult (scan-and-return-first-result tx (prepare-scan-with-limit from 1))
+        ^Result toResult (scan-and-return-first-result tx (prepare-scan-with-limit to 1))]
+    (->> (prepare-put from (calc-new-age fromResult) (calc-new-balance fromResult (- amount)))
+         (.put tx))
+    (->> (prepare-put to (calc-new-age toResult) (calc-new-balance toResult amount))
+         (.put tx))
+    (.commit tx)))
+
+(defn read-record
+  "Read a record with a transaction. If read fails, this function returns nil."
+  [tx id]
+  (try
+    (scan-and-return-first-result tx (prepare-scan-with-limit id 1))
+    (catch CrudException _ nil)))
+
+(defn read-all-records
+  "Read records from 0 .. (n - 1)"
+  [test n]
+  (let [tx (scalar/start-transaction test)]
+    (map #(read-record tx %) (range n))))
+
+(defn read-all-with-retry
+  "Read records from 0 .. (n - 1) and retry if needed"
+  [test n]
+  (when (nil? (deref (:transaction test)))
+    (scalar/prepare-transaction-service! test))
+  (loop [tries scalar/RETRIES]
+    (when (< tries scalar/RETRIES)
+      (scalar/exponential-backoff (- scalar/RETRIES tries)))
+    (when (zero? (mod tries scalar/RETRIES_FOR_RECONNECTION))
+      (scalar/prepare-transaction-service! test))
+    (let [results (read-all-records test n)]
+      (if (empty? (filter nil? results))
+        results
+        (if (pos? tries)
+          (recur (dec tries))
+          (throw (ex-info "Failed to read all records"
+                          {:cause "Failed to read all records"})))))))
+
+(defn get-balance-from-result
+  "Get the balance from a result"
+  [^Result result]
+  (-> result (.getValue BALANCE) .get .get))
+
+(defn get-age-from-result
+  "Get the age from a result"
+  [^Result result]
+  (-> result (.getValue AGE) .get .get))
+
+(defn get-balances-and-ages
+  "Read all records with a transaction. Return the balances and ages."
+  [test n]
+  (let [results (read-all-with-retry test n)]
+    (map #(assoc {} :balance (get-balance-from-result %)
+                    :age (get-age-from-result %))
+         results)))
+
+(defn- try-reconnection!
+  [test]
+  (when (= (swap! (:failures test) inc) NUM_FAILURES_FOR_RECONNECTION)
+    (scalar/prepare-transaction-service! test)
+    (reset! (:failures test) 0)))
+
+(defrecord TransferClient [initialized? n initial-balance]
+  client/Client
+  (open! [_ _ _]
+    (TransferClient. initialized? n initial-balance))
+
+  (setup! [_ test]
+    (locking initialized?
+      (when (compare-and-set! initialized? false true)
+        (let [session (alia/connect
+                        (alia/cluster {:contact-points (->> test :nodes (map name))}))]
+          (create-transfer-table! session test)
+          (scalar/create-coordinator-table! session test)
+          (alia/shutdown session))
+        (scalar/prepare-storage-service! test)
+        (scalar/prepare-transaction-service! test)
+        (populate-accounts test n initial-balance))))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :transfer (if-let [tx (scalar/start-transaction test)]
+                  (try
+                    (tx-transfer tx (-> op :value :from) (-> op :value :to) (-> op :value :amount))
+                    (assoc op :type :ok)
+                    (catch UnknownTransactionStatusException e
+                      (swap! (:unknown-tx test) conj (.getId tx))
+                      (assoc op :type :fail, :error {:unknown-tx-status (.getId tx)}))
+                    (catch Exception e
+                      (try-reconnection! test)
+                      (assoc op :type :fail, :error (.getMessage e))))
+                  (do
+                    (try-reconnection! test)
+                    (assoc op :type :fail, :error "Skipped due to no connection")))
+      :get-all (if-let [result (get-balances-and-ages test (:num op))]
+                 (assoc op :type, :ok :value result)
+                 (assoc op :type, :fail, :error "Failed to get balances and ages"))
+      :get-num-records (if-let [result (let [tx (scalar/start-transaction test)]
+                                         (->> (range (:num op))
+                                              (map prepare-scan)
+                                              (map #(.scan tx %))
+                                              (map count)
+                                              (reduce +)))]
+                         (assoc op :type :ok, :value result)
+                         (assoc op :type :fail, :error "Failed to get number of records"))
+      :check-tx (let [unknown (:unknown-tx test)]
+                  (if-let [num-committed (if (empty? @unknown)
+                                           0
+                                           (scalar/check-transaction-states test @unknown))]
+                    (assoc op :type :ok, :value num-committed)
+                    (assoc op :type :fail, :error "Failed to check status")))))
+
+  (close! [_ _])
+
+  (teardown! [_ test]
+    (scalar/close-all! test)))
+
+(defn transfer
+  [test _]
+  (let [n (-> test :model :num)]
+    {:type  :invoke
+     :f     :transfer
+     :value {:from   (rand-int n)
+             :to     (rand-int n)
+             :amount (+ 1 (rand-int 1000))}}))
+
+(def diff-transfer
+  (gen/filter (fn [op] (not= (-> op :value :from)
+                             (-> op :value :to)))
+              transfer))
+
+(defn get-all
+  [test _]
+  {:type :invoke
+   :f    :get-all
+   :num  (-> test :model :num)})
+
+(defn get-num-records
+  [test _]
+  {:type :invoke
+   :f    :get-num-records
+   :num  (-> test :model :num)})
+
+(defn check-tx
+  [test _]
+  {:type :invoke
+   :f    :check-tx})
+
+(defn consistency-checker
+  []
+  (reify checker/Checker
+    (check [this test history opts]
+      (let [read-result (->> history
+                             (r/filter op/ok?)
+                             (r/filter #(= :get-all (:f %)))
+                             (into [])
+                             last
+                             :value)
+            actual-balance (->> read-result
+                                (map :balance)
+                                (reduce +))
+            bad-balance (if-not (= actual-balance total-balance)
+                          {:type     :wrong-balance
+                           :expected total-balance
+                           :actual   actual-balance})
+            actual-age (->> read-result
+                            (map :age)
+                            (reduce +))
+            expected-age (->> history
+                              (r/filter #(= :get-num-records (:f %)))
+                              (into [])
+                              last
+                              :value)
+            bad-age (if-not (= actual-age expected-age)
+                      {:type     :wrong-age
+                       :expected expected-age
+                       :actual   actual-age})
+            checked-committed (->> history
+                                   (r/filter #(= :check-tx (:f %)))
+                                   (into [])
+                                   last
+                                   ((fn [x]
+                                      (if (= (:type x) :ok) (:value x) 0))))]
+        {:valid?               (and (empty? bad-balance) (empty? bad-age))
+         :total-balance        actual-balance
+         :total-age            actual-age
+         :committed-unknown-tx checked-committed
+         :bad-balance          bad-balance
+         :bad-age              bad-age}))))
+
+(defn transfer-append-test
+  [opts]
+  (merge (scalar/scalardb-test (str "transfer-append-" (:suffix opts))
+                               {:client     (TransferClient. (atom false) NUM_ACCOUNTS INITIAL_BALANCE)
+                                :model      {:num NUM_ACCOUNTS}
+                                :unknown-tx (atom #{})
+                                :failures   (atom 0)
+                                :generator  (gen/phases
+                                              (->> [diff-transfer]
+                                                   (conductors/std-gen opts))
+                                              (conductors/terminate-nemesis opts)
+                                              (gen/clients (gen/once check-tx))
+                                              (gen/clients (gen/once get-all))
+                                              (gen/clients (gen/once get-num-records)))
+                                :checker    (consistency-checker)})
+         opts))

--- a/scalardb/test/scalardb/scalardb_test.clj
+++ b/scalardb/test/scalardb/scalardb_test.clj
@@ -1,0 +1,60 @@
+(ns scalardb.scalardb-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as string]
+            [cassandra
+             [core   :as cassandra]
+             [nemesis :as can]
+             [runner :as car]]
+            [scalardb.transfer :as transfer]
+            [jepsen [core :as jepsen]]))
+
+(def nodes ["n1" "n2" "n3" "n4" "n5"])
+
+(defn check
+  [test-fn nemesis joining clock]
+  (-> {:nodes nodes :rf 3 :db (cassandra/db "3.11.3") :concurrency 5 :time-limit 60}
+      (car/combine-nemesis nemesis joining clock)
+      test-fn
+      jepsen/run!
+      :results
+      :valid?
+      is))
+
+(defmacro add-nemesis
+  [name suffix test-fn joining clock]
+  `(do
+     (deftest ~(symbol (str name "-steady"      suffix))
+              (check ~test-fn `(can/none)                ~joining ~clock))
+     (deftest ~(symbol (str name "-flush"       suffix))
+              (check ~test-fn `(can/flush-and-compacter) ~joining ~clock))
+     (deftest ~(symbol (str name "-bridge"      suffix))
+              (check ~test-fn `(can/bridge)              ~joining ~clock))
+     (deftest ~(symbol (str name "-halves"      suffix))
+              (check ~test-fn `(can/halves)              ~joining ~clock))
+     (deftest ~(symbol (str name "-isolation"   suffix))
+              (check ~test-fn `(can/isolation)           ~joining ~clock))
+     (deftest ~(symbol (str name "-crash"       suffix))
+              (check ~test-fn `(can/crash)               ~joining ~clock))))
+
+(defmacro add-joining
+  [name suffix test-fn clock]
+  `(do
+     (add-nemesis ~name ~(str ""                 suffix) ~test-fn
+                  {:name ""                 :bootstrap false :decommission false} ~clock)
+     (add-nemesis ~name ~(str "-bootstrap"       suffix) ~test-fn
+                  {:name "-bootstrap"       :bootstrap true  :decommission false} ~clock)
+     (add-nemesis ~name ~(str "-decommissioning" suffix) ~test-fn
+                  {:name "-decommissioning" :bootstrap false :decommission true}  ~clock)
+     (add-nemesis ~name ~(str "-rejoining"       suffix) ~test-fn
+                  {:name "-rejoining"       :bootstrap true  :decommission true}  ~clock)))
+
+(defmacro def-tests
+  [test-fn]
+  (let [name# (-> test-fn name (string/replace "-test" ""))]
+    `(do
+       (add-joining name# ""              ~test-fn {:name ""              :bump false :strobe false})
+       (add-joining name# "-clock-bump"   ~test-fn {:name "-clock-bump"   :bump true  :strobe false})
+       (add-joining name# "-clock-strobe" ~test-fn {:name "-clock-strobe" :bump false :strobe true})
+       (add-joining name# "-clock-drift"  ~test-fn {:name "-clock-drift"  :bump true  :strobe true}))))
+
+(def-tests transfer/transfer-test)


### PR DESCRIPTION
Just copy files from `scalar-labs/jepsen/cassandra` and `scalar-labs/scalardb/jepsen/scalardb`

I've checked if I can run tests with Jepsen docker in https://github.com/jepsen-io/jepsen.
I wrote how to run in the new `README.md`.