### PR TITLE
Update docker image and dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/scalar-jepsen
 
     docker:
-      - image: circleci/clojure:lein-2.9.1
+      - image: circleci/clojure:openjdk-8-lein-2.9.1
 
     environment:
       JVM_OPTS: -Xmx3200m

--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -3,13 +3,12 @@
   :url "http://github.com/scalar-labs/jepsen"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/java.jmx "0.3.1"]
                  [jepsen "0.1.13"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [tortue/spy "2.0.0"]]
-                   :plugins [[lein-cloverage "1.1.1"]]}}
+  :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
+                   :plugins [[lein-cloverage "1.1.2"]]}}
   :main cassandra.runner
   :aot [cassandra.runner])

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -3,14 +3,13 @@
   :url "https://github.com/scalar-labs/scalardb"
   :license {:name ""
             :url ""}
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [jepsen "0.1.13"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]
                  [com.scalar-labs/scalardb "1.0.0" :exclusions [org.slf4j/slf4j-log4j12]]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
-                                  [tortue/spy "2.0.0"]]
-                   :plugins [[lein-cloverage "1.1.1"]]}}
+  :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
+                   :plugins [[lein-cloverage "1.1.2"]]}}
   :main scalardb.runner
   :aot [scalardb.runner])

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/scalar-labs/scalar-jepsen"
   :license {:name ""
             :url ""}
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [jepsen "0.1.13"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
@@ -11,9 +11,8 @@
                  [com.scalar-labs/scalardl-client-sdk "1.2.0"
                   :exclusions [[org.slf4j/slf4j-log4j12]
                                [com.google.guava/guava]]]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
-                                  [tortue/spy "2.0.0"]]
-                   :plugins [[lein-cloverage "1.1.1"]]}}
+  :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
+                   :plugins [[lein-cloverage "1.1.2"]]}}
   :java-source-paths ["contract"]
   :main scalardl.runner
   :aot :all)


### PR DESCRIPTION
- Modify the docker image of CircleCI/Clojure to `openjdk-8-lein-2.9.1`
- Update to Clojure 1.10.1
- Update cloverage to 1.1.2
