### PR TITLE
add apt update

### DIFF
--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -111,6 +111,7 @@
             (try
               (c/su (debian/install [:openjdk-8-jre]))
               (catch clojure.lang.ExceptionInfo e
+                (debian/update!)
                 (if (= tries 7)
                   (throw e)
                   (step (inc tries))))))]
@@ -265,6 +266,5 @@
 (defn cassandra-test
   [name opts]
   (merge tests/noop-test
-         {:name (str "cassandra-" name)
-          :os   debian/os}
+         {:name (str "cassandra-" name)}
          opts))

--- a/cassandra/test/cassandra/core_test.clj
+++ b/cassandra/test/cassandra/core_test.clj
@@ -112,6 +112,7 @@
                   debian/install (spy/mock (fn [a]
                                              (throw (ex-info
                                                      "install failed!" {}))))
+                  debian/update! (spy/spy)
                   c/upload (spy/spy)
                   cu/install-archive! (spy/spy)]
       (is (thrown? clojure.lang.ExceptionInfo (cass/install! "n1" test)))

--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -175,6 +175,5 @@
   [name opts]
   (merge tests/noop-test
          {:name (str "scalardl-" name)
-          :os debian/os
           :db (db)}
          opts))


### PR DESCRIPTION
- Remove specifying `debian/os` since some packages have been installed
  - It just installs some packages
- Add `apt-get update` when JDK install failed
  - According to my investigation, JDK install failed when some dependent packages are old. After retrying `apt-get update`, it works well.