### PR TITLE
Upgrade Jepsen to 0.1.15

### DIFF
--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/java.jmx "0.3.1"]
-                 [jepsen "0.1.13"]
+                 [jepsen "0.1.15"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -4,7 +4,7 @@
   :license {:name ""
             :url ""}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.1.13"]
+                 [jepsen "0.1.15"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -4,7 +4,7 @@
   :license {:name ""
             :url ""}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.1.13"]
+                 [jepsen "0.1.15"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]


### PR DESCRIPTION
I want to upgrade Jepsen.
We had an error of wget. jepsen.control.util/wget retries since 0.1.14. 

Ref. https://github.com/jepsen-io/jepsen/releases