### PR TITLE
Handle TransportException and WriteTimeoutException

### DIFF
--- a/cassandra/src/cassandra/batch.clj
+++ b/cassandra/src/cassandra/batch.clj
@@ -9,11 +9,7 @@
             [qbits.alia :as alia]
             [qbits.hayt.dsl.clause :refer :all]
             [qbits.hayt.dsl.statement :refer :all])
-  (:import (clojure.lang ExceptionInfo)
-           (com.datastax.driver.core.exceptions NoHostAvailableException
-                                                ReadTimeoutException
-                                                WriteTimeoutException
-                                                UnavailableException)))
+  (:import (clojure.lang ExceptionInfo)))
 
 (defrecord BatchSetClient [tbl-created? cluster session]
   client/Client
@@ -63,15 +59,7 @@
                   (assoc op :type :fail :value [value-a value-b]))))
 
       (catch ExceptionInfo e
-        (let [e (class (:exception (ex-data e)))]
-          (condp = e
-            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
-            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
-            UnavailableException (assoc op :type :fail, :error :unavailable)
-            NoHostAvailableException (do
-                                       (info "All the servers are down - waiting 2s")
-                                       (Thread/sleep 2000)
-                                       (assoc op :type :fail, :error :no-host-available)))))))
+        (handle-exception op e))))
 
   (close! [_ _]
     (close-cassandra cluster session))

--- a/cassandra/src/cassandra/collections/map.clj
+++ b/cassandra/src/cassandra/collections/map.clj
@@ -10,11 +10,7 @@
             [qbits.hayt.utils :refer [map-type]]
             [cassandra.core :refer :all]
             [cassandra.conductors :as conductors])
-  (:import (clojure.lang ExceptionInfo)
-           (com.datastax.driver.core.exceptions NoHostAvailableException
-                                                ReadTimeoutException
-                                                WriteTimeoutException
-                                                UnavailableException)))
+  (:import (clojure.lang ExceptionInfo)))
 
 (defrecord CQLMapClient [tbl-created? cluster session writec]
   client/Client
@@ -55,15 +51,7 @@
                 (assoc op :type :ok, :value value)))
 
       (catch ExceptionInfo e
-        (let [e (class (:exception (ex-data e)))]
-          (condp = e
-            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
-            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
-            UnavailableException (assoc op :type :fail, :error :unavailable)
-            NoHostAvailableException (do
-                                       (info "All the servers are down - waiting 2s")
-                                       (Thread/sleep 2000)
-                                       (assoc op :type :fail, :error :no-host-available)))))))
+        (handle-exception op e))))
 
   (close! [_ _]
     (close-cassandra cluster session))

--- a/cassandra/src/cassandra/counter.clj
+++ b/cassandra/src/cassandra/counter.clj
@@ -11,11 +11,7 @@
             [qbits.hayt.dsl.clause :refer :all]
             [qbits.hayt.dsl.statement :refer :all]
             [qbits.alia.policy.retry :as retry])
-  (:import (clojure.lang ExceptionInfo)
-           (com.datastax.driver.core.exceptions NoHostAvailableException
-                                                ReadTimeoutException
-                                                WriteTimeoutException
-                                                UnavailableException)))
+  (:import (clojure.lang ExceptionInfo)))
 
 (defrecord CQLCounterClient [tbl-created? cluster session writec]
   client/Client
@@ -57,15 +53,7 @@
                 (assoc op :type :ok, :value value)))
 
       (catch ExceptionInfo e
-        (let [e (class (:exception (ex-data e)))]
-          (condp = e
-            WriteTimeoutException (assoc op :type :info, :value :write-timed-out)
-            ReadTimeoutException (assoc op :type :fail, :error :read-timed-out)
-            UnavailableException (assoc op :type :fail, :error :unavailable)
-            NoHostAvailableException (do
-                                       (info "All the servers are down - waiting 2s")
-                                       (Thread/sleep 2000)
-                                       (assoc op :type :fail, :error :no-host-available)))))))
+        (handle-exception op e))))
 
   (close! [_ _]
     (close-cassandra cluster session))

--- a/cassandra/test/cassandra/batch_test.clj
+++ b/cassandra/test/cassandra/batch_test.clj
@@ -5,7 +5,8 @@
             [cassandra.core :as cassandra]
             [cassandra.batch :as batch :refer (->BatchSetClient)]
             [spy.core :as spy])
-  (:import (com.datastax.driver.core.exceptions NoHostAvailableException
+  (:import (com.datastax.driver.core WriteType)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
                                                 ReadTimeoutException
                                                 WriteTimeoutException
                                                 UnavailableException)))
@@ -91,7 +92,7 @@
                                 (when (and (string? cql) (re-find #"BATCH" cql))
                                   (throw (ex-info "Timed out"
                                                   {:type ::execute
-                                                   :exception (WriteTimeoutException. nil nil nil 0 0)})))))]
+                                                   :exception (WriteTimeoutException. nil nil WriteType/BATCH_LOG 0 0)})))))]
     (let [client (client/open! (->BatchSetClient (atom false) nil nil)
                                {:nodes ["n1" "n2" "n3"]} nil)
           add-result (client/invoke! client {}

--- a/cassandra/test/cassandra/lwt_test.clj
+++ b/cassandra/test/cassandra/lwt_test.clj
@@ -6,7 +6,8 @@
             [cassandra.core :as cassandra]
             [cassandra.lwt :refer [->CasRegisterClient] :as lwt]
             [spy.core :as spy])
-  (:import (com.datastax.driver.core.exceptions NoHostAvailableException
+  (:import (com.datastax.driver.core WriteType)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
                                                 ReadTimeoutException
                                                 WriteTimeoutException
                                                 UnavailableException)))
@@ -139,7 +140,7 @@
                                 (when (contains? cql :update)
                                   (throw (ex-info "Timed out"
                                                   {:type ::execute
-                                                   :exception (WriteTimeoutException. nil nil nil 0 0)})))))]
+                                                   :exception (WriteTimeoutException. nil nil WriteType/CAS 0 0)})))))]
     (let [client (client/open! (->CasRegisterClient (atom false) nil nil)
                                {:nodes ["n1" "n2" "n3"]} nil)
           result (client/invoke! client {}

--- a/cassandra/test/cassandra/map_test.clj
+++ b/cassandra/test/cassandra/map_test.clj
@@ -5,7 +5,8 @@
             [cassandra.core :as cassandra]
             [cassandra.collections.map :refer [->CQLMapClient] :as map]
             [spy.core :as spy])
-  (:import (com.datastax.driver.core.exceptions NoHostAvailableException
+  (:import (com.datastax.driver.core WriteType)
+           (com.datastax.driver.core.exceptions NoHostAvailableException
                                                 ReadTimeoutException
                                                 WriteTimeoutException
                                                 UnavailableException)))
@@ -92,8 +93,8 @@
                                {:nodes ["n1" "n2" "n3"]} nil)
           add-result (client/invoke! client {}
                                      {:type :invoke :f :add :value 1})]
-      (is (= :info (:type add-result)))
-      (is (= :write-timed-out (:value add-result))))))
+      (is (= :fail (:type add-result)))
+      (is (= :write-timed-out (:error add-result))))))
 
 (deftest map-client-unavailable-exception-test
   (with-redefs [alia/cluster (spy/spy)

--- a/cassandra/test/cassandra/set_test.clj
+++ b/cassandra/test/cassandra/set_test.clj
@@ -77,8 +77,8 @@
                                {:nodes ["n1" "n2" "n3"]} nil)
           add-result (client/invoke! client {}
                                      {:type :invoke :f :add :value 1})]
-      (is (= :info (:type add-result)))
-      (is (= :write-timed-out (:value add-result))))))
+      (is (= :fail (:type add-result)))
+      (is (= :write-timed-out (:error add-result))))))
 
 (deftest set-client-unavailable-exception-test
   (with-redefs [alia/cluster (spy/spy)


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-4376

- Move exception handling to `cassandra/core.clj`

- Handle TransportException
  - Jepsen checker failed because this exception wasn't handled properly

- Handle WriteTimeoutException
  - Check WriteType for recognizing the write can be applied
  - Reduce `:info` type which takes a long time to check the consistency