### PR TITLE
Wait for batchlog replay

### DIFF
--- a/cassandra/src/cassandra/batch.clj
+++ b/cassandra/src/cassandra/batch.clj
@@ -75,5 +75,6 @@
                                       (->> [(adds)]
                                            (conductors/std-gen opts))
                                       (conductors/terminate-nemesis opts)
-                                      (read-once))})
+                                      ; read after waiting for batchlog replay
+                                      (gen/delay 60 (read-once)))})
          opts))


### PR DESCRIPTION
A test failed when a batch write was delayed by network failure.
https://scalar-labs.atlassian.net/browse/DLT-4416

- Waits for batchlog reply before reading all records