### PR TITLE
catch TransportException when use-keyspace fails

### DIFF
--- a/cassandra/src/cassandra/batch.clj
+++ b/cassandra/src/cassandra/batch.clj
@@ -30,8 +30,8 @@
                                            :primary-key [:pid :cid]}}))))
 
   (invoke! [_ _ op]
-    (alia/execute session (use-keyspace :jepsen_keyspace))
     (try
+      (alia/execute session (use-keyspace :jepsen_keyspace))
       (case (:f op)
         :add (let [value (:value op)]
                (alia/execute session

--- a/cassandra/src/cassandra/collections/map.clj
+++ b/cassandra/src/cassandra/collections/map.clj
@@ -32,8 +32,8 @@
                                                      [:elements {}]]))))))
 
   (invoke! [_ _ op]
-    (alia/execute session (use-keyspace :jepsen_keyspace))
     (try
+      (alia/execute session (use-keyspace :jepsen_keyspace))
       (case (:f op)
         :add (do (alia/execute session
                                (update :maps

--- a/cassandra/src/cassandra/collections/set.clj
+++ b/cassandra/src/cassandra/collections/set.clj
@@ -35,8 +35,8 @@
                                       (if-exists false))))))
 
   (invoke! [_ _ op]
-    (alia/execute session (use-keyspace :jepsen_keyspace))
     (try
+      (alia/execute session (use-keyspace :jepsen_keyspace))
       (case (:f op)
         :add (do (alia/execute session
                                (update :sets

--- a/cassandra/src/cassandra/lwt.clj
+++ b/cassandra/src/cassandra/lwt.clj
@@ -34,8 +34,8 @@
                                            :primary-key [:id]}}))))
 
   (invoke! [_ _ op]
-    (alia/execute session (use-keyspace :jepsen_keyspace))
     (try
+      (alia/execute session (use-keyspace :jepsen_keyspace))
       (case (:f op)
         :cas (let [[old new] (:value op)
                    result (alia/execute session


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-4572

`TransportException` couldn’t be caught when a session tries `use-keyspace` failed.
