### PR TITLE
Return :info when WriteTimeoutException for counter write

### DIFF
--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -268,7 +268,7 @@
   (some-> cluster alia/shutdown (.get 10 TimeUnit/SECONDS)))
 
 (defn handle-exception
-  [op ^ExceptionInfo e]
+  [op ^ExceptionInfo e & conditional?]
   (let [ex (:exception (ex-data e))
         exception-class (class ex)]
     (condp = exception-class
@@ -279,7 +279,11 @@
                               WriteType/BATCH_LOG (assoc op
                                                          :type :info
                                                          :value :write-timed-out)
-                              WriteType/SIMPLE (assoc op :type :ok)
+                              WriteType/SIMPLE (if conditional?
+                                                 (assoc op :type :ok)
+                                                 (assoc op
+                                                        :type :info
+                                                        :value :write-timed-out))
                               WriteType/BATCH (assoc op :type :ok)
                               WriteType/COUNTER (assoc op
                                                        :type :info

--- a/cassandra/src/cassandra/counter.clj
+++ b/cassandra/src/cassandra/counter.clj
@@ -41,8 +41,7 @@
                                (update :counters
                                        (set-columns {:count [+ (:value op)]})
                                        (where [[= :id 0]]))
-                               {:consistency  writec
-                                :retry-policy (retry/fallthrough-retry-policy)})
+                               {:consistency  writec})
                  (assoc op :type :ok))
         :read (let [value (->> (alia/execute session
                                              (select :counters (where [[= :id 0]]))

--- a/cassandra/src/cassandra/lwt.clj
+++ b/cassandra/src/cassandra/lwt.clj
@@ -70,7 +70,7 @@
                 (assoc op :type :ok, :value v)))
 
       (catch ExceptionInfo e
-        (handle-exception op e))))
+        (handle-exception op e true))))
 
   (close! [_ _]
     (close-cassandra cluster session))

--- a/cassandra/test/cassandra/core_test.clj
+++ b/cassandra/test/cassandra/core_test.clj
@@ -270,8 +270,10 @@
                          {:type :execute
                           :exception (NoHostAvailableException. {})})]
     (is (= {:type :info :value :write-timed-out}
-           (cass/handle-exception op cas-timeout)))
+           (cass/handle-exception op cas-timeout true)))
     (is (= {:type :ok}
+           (cass/handle-exception op simple-timeout true)))
+    (is (= {:type :info :value :write-timed-out}
            (cass/handle-exception op simple-timeout)))
     (is (= {:type :info :value :write-timed-out}
            (cass/handle-exception op batch-log-timeout)))

--- a/cassandra/test/cassandra/counter_test.clj
+++ b/cassandra/test/cassandra/counter_test.clj
@@ -42,8 +42,7 @@
                             {:update :counters
                              :set-columns {:count [+ 1]}
                              :where [[= :id 0]]}
-                            {:consistency :quorum
-                             :retry-policy (retry/fallthrough-retry-policy)}))
+                            {:consistency :quorum}))
       (is (= :ok (:type result))))))
 
 (deftest counter-client-read-test
@@ -96,8 +95,8 @@
                                {:nodes ["n1" "n2" "n3"]} nil)
           result (client/invoke! client {}
                                  {:type :invoke :f :add :value 1})]
-      (is (= :fail (:type result)))
-      (is (= :write-timed-out (:error result))))))
+      (is (= :info (:type result)))
+      (is (= :write-timed-out (:value result))))))
 
 (deftest counter-client-unavailable-exception-test
   (with-redefs [alia/cluster (spy/spy)


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-4646
https://scalar-labs.atlassian.net/browse/DLT-4650

In the counter test, after WriteTimeoutException, some values had been applied eventually.
However, all results were `:fail` when WriteTimeoutException in the counter test.

I want to fix this error handling to return `:info` because a value might be applied eventually.

And, I remove the unneeded retry for the counter write.
Retry operation is complicated and the unexpected exception should be removed.