### PR TITLE
change the result to :info when TransportException

### DIFF
--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -290,7 +290,7 @@
                                                        :value :write-timed-out)
                               (assoc op :type :fail :error :write-timed-out))
       ReadTimeoutException (assoc op :type :fail :error :read-timed-out)
-      TransportException (assoc op :type :fail :error :node-down)
+      TransportException (assoc op :type :info :value :node-down)
       UnavailableException (assoc op :type :fail :error :unavailable)
       NoHostAvailableException (do
                                  (info "All the servers are down - waiting 2s")

--- a/cassandra/test/cassandra/core_test.clj
+++ b/cassandra/test/cassandra/core_test.clj
@@ -281,7 +281,7 @@
            (cass/handle-exception op batch-timeout)))
     (is (= {:type :fail :error :read-timed-out}
            (cass/handle-exception op read-timeout)))
-    (is (= {:type :fail :error :node-down}
+    (is (= {:type :info :value :node-down}
            (cass/handle-exception op node-down)))
     (is (= {:type :fail :error :unavailable}
            (cass/handle-exception op unavailable)))


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-4785

In the counter test, some counter writes had applied values when TransportException (a node is down).

- Change the result from `:fail` to `:info` when TransportException.