### PR TITLE
update jepsen for DB and DL

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -4,7 +4,7 @@
   :license {:name ""
             :url ""}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.1.15"]
+                 [jepsen "0.1.18"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -4,7 +4,7 @@
   :license {:name ""
             :url ""}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.1.15"]
+                 [jepsen "0.1.18"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]]


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6296

Cause: C* test uses Jepsen `0.1.18`, but DB and DL tests use `0.1.15`