### PR TITLE
Fix DL server option

### DIFF
--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -139,7 +139,7 @@
   (info node "starting DL server")
   (cu/start-daemon! {:logfile LEDGER_LOG :pidfile LEDGER_PID :chdir LEDGER_INSTALL_DIR}
                     LEDGER_EXE
-                    :-config LEDGER_PROPERTIES))
+                    :--config LEDGER_PROPERTIES))
 
 (defn stop-server!
   [node]


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6435
https://scalar-labs.atlassian.net/browse/DLT-6433

I found the root cause of test failures.
An option `-config` of a DL server was updated last week. However, I didn't update that.
I didn't have to add retry for DL tests. But I don't want to revert because it is helpful when the network is unstable.