### PR TITLE
check transaction states after getting all balances

### DIFF
--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -244,7 +244,7 @@
                                              (->> [diff-transfer]
                                                   (conductors/std-gen opts))
                                              (conductors/terminate-nemesis opts)
-                                             (gen/clients (gen/once check-tx))
-                                             (gen/clients (gen/once get-all)))
+                                             (gen/clients (gen/once get-all))
+                                             (gen/clients (gen/once check-tx)))
                                 :checker    (consistency-checker)})
          opts))

--- a/scalardl/src/scalardl/transfer.clj
+++ b/scalardl/src/scalardl/transfer.clj
@@ -215,7 +215,7 @@
                             :generator  (gen/phases
                                          (conductors/std-gen opts [diff-transfer])
                                          (conductors/terminate-nemesis opts)
-                                         (gen/clients (gen/once check-tx))
-                                         (gen/clients (gen/once get-all)))
+                                         (gen/clients (gen/once get-all))
+                                         (gen/clients (gen/once check-tx)))
                             :checker   (asset-checker)})
          opts))


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6462
https://scalar-labs.atlassian.net/browse/DLT-6463
https://scalar-labs.atlassian.net/browse/DLT-6493

These failures were caused by write delay for the transaction states.
I think it is better to check the coordinator.state table after getting all balances.
That's because an unknown state will be fixed by getting each balance.