### PR TITLE
Fix check-tx-state

### DIFF
--- a/scalardl/src/scalardl/cas.clj
+++ b/scalardl/src/scalardl/cas.clj
@@ -52,7 +52,7 @@
   [e op txid test]
   (if (util/unknown? e)
     (try
-      (if (dl/check-tx-committed? txid test)
+      (if (dl/committed? txid test)
         (assoc op :type :ok)
         (assoc op :type :fail :error :state-write-failure))
       (catch clojure.lang.ExceptionInfo ex

--- a/scalardl/src/scalardl/cas.clj
+++ b/scalardl/src/scalardl/cas.clj
@@ -51,12 +51,12 @@
 (defn- handle-exception
   [e op txid test]
   (if (util/unknown? e)
-    (let [committed (dl/check-tx-committed txid test)]
-      (if (nil? committed)
-        (assoc op :type :info :error (.getMessage e)) ;; unknown
-        (if committed
-          (assoc op :type :ok)
-          (assoc op :type :fail :error (.getMessage e)))))
+    (try
+      (if (dl/check-tx-committed? txid test)
+        (assoc op :type :ok)
+        (assoc op :type :fail :error :state-write-failure))
+      (catch clojure.lang.ExceptionInfo ex
+        (assoc op :type :info :error (.getMessage ex)))) ;; unknown
     (assoc op :type :fail :error (util/get-exception-info e))))
 
 (defrecord CasRegisterClient [initialized? client-service]

--- a/scalardl/src/scalardl/cassandra.clj
+++ b/scalardl/src/scalardl/cassandra.clj
@@ -11,7 +11,7 @@
   [test]
   (cassandra/cassandra-log test))
 
-(defn check-tx-state?
+(defn committed?
   "Return true/false when the transaction has been committed or aborted"
   [txid {:keys [cass-nodes]}]
   (let [cluster (alia/cluster {:contact-points cass-nodes})
@@ -21,7 +21,9 @@
                                 {:consistency :serial})
                   (catch Exception e (throw e))
                   (finally (alia/shutdown cluster)))]
-    (= (some-> rows first :tx_state) TX_COMMITTED)))
+    (if (empty? rows)
+      (throw (ex-info "no entry for the state" {}))
+      (= (-> rows first :tx_state) TX_COMMITTED))))
 
 (defn spinup-cassandra!
   [node test]

--- a/scalardl/src/scalardl/cassandra.clj
+++ b/scalardl/src/scalardl/cassandra.clj
@@ -6,25 +6,22 @@
             [qbits.hayt.dsl.statement :refer :all]))
 
 (def ^:private ^:const TX_COMMITTED 3)
-(def ^:private ^:const TX_ABORTED 4)
 
 (defn cassandra-log
   [test]
   (cassandra/cassandra-log test))
 
-(defn check-tx-state
-  "Return true/false when the transaction has been committed or aborted.
-  Return nil when it can't read the state from the coordinator table"
+(defn check-tx-state?
+  "Return true/false when the transaction has been committed or aborted"
   [txid {:keys [cass-nodes]}]
   (let [cluster (alia/cluster {:contact-points cass-nodes})
         rows (try (alia/execute (alia/connect cluster)
                                 (select :coordinator.state
                                         (where {:tx_id txid}))
                                 {:consistency :serial})
-                  (catch Exception _
-                    (warn "Failed to read the coordinator table"))
+                  (catch Exception e (throw e))
                   (finally (alia/shutdown cluster)))]
-    (if rows (= (-> rows first :tx_state) TX_COMMITTED) nil)))
+    (= (some-> rows first :tx_state) TX_COMMITTED)))
 
 (defn spinup-cassandra!
   [node test]

--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -98,10 +98,10 @@
                                                (Optional/empty)))
                           [c])))
 
-(defn check-tx-committed?
+(defn committed?
   [txid test]
   (info "checking a TX state" txid)
-  (retry-when-exception cassandra/check-tx-state? [txid test]))
+  (retry-when-exception cassandra/committed? [txid test]))
 
 (defn- create-server-properties
   [test]

--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -33,10 +33,10 @@
 
 (defn- retry-when-exception*
   [tries f args fallback]
-  (if (pos? tries)
+  (when (pos? tries)
     (let [res (try {:value (apply f args)}
                    (catch Exception e
-                     (if (zero? tries)
+                     (if (= tries 1)
                        (throw e)
                        {:exception e})))]
       (if-let [e (:exception res)]
@@ -98,15 +98,10 @@
                                                (Optional/empty)))
                           [c])))
 
-(defn check-tx-committed
+(defn check-tx-committed?
   [txid test]
   (info "checking a TX state" txid)
-  (retry-when-exception (fn [id t]
-                          (if-let [committed (cassandra/check-tx-state id t)]
-                            committed
-                            (throw (ex-info "Failed to read the TX state"
-                                            {:cause :read-state-failure}))))
-                        [txid test]))
+  (retry-when-exception cassandra/check-tx-state? [txid test]))
 
 (defn- create-server-properties
   [test]

--- a/scalardl/src/scalardl/transfer.clj
+++ b/scalardl/src/scalardl/transfer.clj
@@ -87,11 +87,10 @@
 
 (defn- check-tx-states
   [test]
-  (let [unknowns @(:unknown-tx test)
-        committed (mapv #(dl/check-tx-committed % test) unknowns)]
-    (if (some nil? committed)
-      nil
-      (->> committed (filter true?) count))))
+  (->> @(:unknown-tx test)
+       (mapv #(dl/check-tx-committed? % test))
+       (filter true?)
+       count))
 
 (defrecord TransferClient [initialized? client-service n]
   client/Client

--- a/scalardl/src/scalardl/transfer.clj
+++ b/scalardl/src/scalardl/transfer.clj
@@ -88,7 +88,7 @@
 (defn- check-tx-states
   [test]
   (->> @(:unknown-tx test)
-       (mapv #(dl/check-tx-committed? % test))
+       (mapv #(dl/committed? % test))
        (filter true?)
        count))
 

--- a/scalardl/test/scalardl/cas_test.clj
+++ b/scalardl/test/scalardl/cas_test.clj
@@ -101,41 +101,41 @@
 (deftest cas-client-cas-unknown-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service-throws-unknown-status)
                 dl/try-switch-server! (spy/stub mock-client-service)
-                dl/check-tx-committed? (spy/mock (fn [_ _]
-                                                   (throw
-                                                    (ex-info "fail" {}))))]
+                dl/committed? (spy/mock (fn [_ _]
+                                          (throw
+                                           (ex-info "fail" {}))))]
     (let [client (client/open! (cas/->CasRegisterClient (atom false) (atom nil))
                                nil nil)
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/called-once? dl/check-tx-committed?))
+      (is (spy/called-once? dl/committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :info (:type result))))))
 
 (deftest cas-client-cas-commit-after-unknown-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service-throws-unknown-status)
                 dl/try-switch-server! (spy/stub mock-client-service)
-                dl/check-tx-committed? (spy/stub true)]
+                dl/committed? (spy/stub true)]
     (let [client (client/open! (cas/->CasRegisterClient (atom false) (atom nil))
                                nil nil)
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/called-once? dl/check-tx-committed?))
+      (is (spy/called-once? dl/committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :ok (:type result))))))
 
 (deftest cas-client-cas-abort-after-unknown-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service-throws-unknown-status)
                 dl/try-switch-server! (spy/stub mock-client-service)
-                dl/check-tx-committed? (spy/stub false)]
+                dl/committed? (spy/stub false)]
     (let [client (client/open! (cas/->CasRegisterClient (atom false) (atom nil))
                                nil nil)
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/called-once? dl/check-tx-committed?))
+      (is (spy/called-once? dl/committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :fail (:type result))))))
 
@@ -147,6 +147,6 @@
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/not-called? dl/check-tx-committed?))
+      (is (spy/not-called? dl/committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :fail (:type result))))))

--- a/scalardl/test/scalardl/cas_test.clj
+++ b/scalardl/test/scalardl/cas_test.clj
@@ -101,39 +101,41 @@
 (deftest cas-client-cas-unknown-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service-throws-unknown-status)
                 dl/try-switch-server! (spy/stub mock-client-service)
-                dl/check-tx-committed (spy/stub nil)]
+                dl/check-tx-committed? (spy/mock (fn [_ _]
+                                                   (throw
+                                                    (ex-info "fail" {}))))]
     (let [client (client/open! (cas/->CasRegisterClient (atom false) (atom nil))
                                nil nil)
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/called-once? dl/check-tx-committed))
+      (is (spy/called-once? dl/check-tx-committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :info (:type result))))))
 
 (deftest cas-client-cas-commit-after-unknown-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service-throws-unknown-status)
                 dl/try-switch-server! (spy/stub mock-client-service)
-                dl/check-tx-committed (spy/stub true)]
+                dl/check-tx-committed? (spy/stub true)]
     (let [client (client/open! (cas/->CasRegisterClient (atom false) (atom nil))
                                nil nil)
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/called-once? dl/check-tx-committed))
+      (is (spy/called-once? dl/check-tx-committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :ok (:type result))))))
 
 (deftest cas-client-cas-abort-after-unknown-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service-throws-unknown-status)
                 dl/try-switch-server! (spy/stub mock-client-service)
-                dl/check-tx-committed (spy/stub false)]
+                dl/check-tx-committed? (spy/stub false)]
     (let [client (client/open! (cas/->CasRegisterClient (atom false) (atom nil))
                                nil nil)
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/called-once? dl/check-tx-committed))
+      (is (spy/called-once? dl/check-tx-committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :fail (:type result))))))
 
@@ -145,6 +147,6 @@
           test {:unknown-tx (atom #{})}
           result (client/invoke! client test (#'cas/cas nil nil))]
       (is (spy/called-once? dl/try-switch-server!))
-      (is (spy/not-called? dl/check-tx-committed))
+      (is (spy/not-called? dl/check-tx-committed?))
       (is (= mock-client-service @(:client-service client)))
       (is (= :fail (:type result))))))

--- a/scalardl/test/scalardl/cassandra_test.clj
+++ b/scalardl/test/scalardl/cassandra_test.clj
@@ -1,0 +1,30 @@
+(ns scalardl.cassandra-test
+  (:require [clojure.test :refer :all]
+            [qbits.alia :as alia]
+            [scalardl.cassandra :as cassandra]
+            [spy.core :as spy]))
+
+(def TX_COMMITTED 3)
+
+(deftest check-tx-state-test
+  (with-redefs [alia/cluster (spy/stub "cluster")
+                alia/connect (spy/stub "session")
+                alia/execute (spy/stub [{:tx_state TX_COMMITTED}])]
+    (is (true? (cassandra/check-tx-state? "txid"
+                                          {:cass-nodes "localhost"})))))
+
+(deftest check-tx-state-no-state-test
+  (with-redefs [alia/cluster (spy/stub "cluster")
+                alia/connect (spy/stub "session")
+                alia/execute (spy/stub [])]
+    (is (false? (cassandra/check-tx-state? "txid"
+                                           {:cass-nodes "localhost"})))))
+
+(deftest check-tx-state-fail-test
+  (with-redefs [alia/cluster (spy/stub "cluster")
+                alia/connect (spy/stub "session")
+                alia/execute (spy/mock (fn [_ _ _]
+                                         (throw (ex-info "fail" {}))))]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (cassandra/check-tx-state? "txid"
+                                            {:cass-nodes "localhost"})))))

--- a/scalardl/test/scalardl/transfer_test.clj
+++ b/scalardl/test/scalardl/transfer_test.clj
@@ -89,7 +89,7 @@
 
 (deftest transfer-client-check-tx-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service)
-                dl/check-tx-committed? (spy/stub true)]
+                dl/committed? (spy/stub true)]
     (let [client (client/open! (transfer/->TransferClient (atom false)
                                                           (atom nil) 5)
                                nil nil)
@@ -101,9 +101,9 @@
 
 (deftest transfer-client-check-tx-fail-test
   (with-redefs [dl/prepare-client-service (spy/stub mock-client-service)
-                dl/check-tx-committed? (spy/mock (fn [_ _]
-                                                   (throw
-                                                     (ex-info "fail" {}))))]
+                dl/committed? (spy/mock (fn [_ _]
+                                          (throw
+                                           (ex-info "fail" {}))))]
     (let [client (client/open! (transfer/->TransferClient (atom false)
                                                           (atom nil) 5)
                                nil nil)]


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6558

Issue:
- When ABORTED state exists or the state doesn't exist, the count of committed transactions was wrong

Cause:
- When ABORTED state exists or the state doesn't exist, `check-tx-committed` throws an exception
- No exception was thrown in `check-tx-state`

Fix:
- `check-tx-state?` can throw an exception when the read fails
- `check-tx-committed` can returns `false`
- `retry-when-exception` can throw an exception when the last failure
- Some unit tests are modified and added