### PR TITLE
Add elle-append test

### DIFF
--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/java.jmx "0.3.1"]
                  [jepsen "0.2.1"]
-                 [cc.qbits/alia "4.3.1"]
+                 [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}}

--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -24,4 +24,5 @@ The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar
     $ lein run test --test transfer --nemesis crash --join decommission --time-limit 300
     ```
 
+  - For elle-append test, `graphviz` is required
   - See `lein run test --help` for full options

--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -24,5 +24,5 @@ The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar
     $ lein run test --test transfer --nemesis crash --join decommission --time-limit 300
     ```
 
-  - For elle-append test, `graphviz` is required
+  - For elle-append test, `graphviz` package is required
   - See `lein run test --help` for full options

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -1,18 +1,19 @@
 (defproject scalardb "0.1.0-SNAPSHOT"
   :description "Jepsen testing for Scalar DB"
-  :url "https://github.com/scalar-labs/scalardb"
-  :license {:name ""
-            :url ""}
+  :url "https://github.com/scalar-labs/scalar-jepsen"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [jepsen "0.2.1"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.6"]
-                 [cc.qbits/hayt "4.1.0"]
-                 [software.amazon.awssdk/sdk-core "2.14.24"]
-                 [com.scalar-labs/scalardb "2.4.0"
-                  :exclusions [software.amazon.awssdk/core]]]
+                 [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
-                   :plugins [[lein-cloverage "1.1.2"]]}}
+                   :plugins [[lein-cloverage "1.1.2"]]}
+             :use-released {:dependencies [[com.scalar-labs/scalardb "2.4.0"
+                                            :exclusions [software.amazon.awssdk/core]]]}
+             :use-jars {:dependencies [[com.google.inject/guice "4.2.0"]
+                                       [com.google.guava/guava "24.1-jre"]]
+                        :resource-paths ["resources/scalardb.jar"]}
+             :default [:base :system :user :provided :dev :use-released]}
   :jvm-opts ["-Djava.awt.headless=true"]
   :main scalardb.runner
   :aot [scalardb.runner])

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -6,9 +6,11 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [jepsen "0.2.1"]
                  [cassandra "0.1.0-SNAPSHOT"]
-                 [cc.qbits/alia "4.3.1"]
+                 [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]
-                 [com.scalar-labs/scalardb "2.1.0" :exclusions [org.slf4j/slf4j-log4j12]]]
+                 [software.amazon.awssdk/sdk-core "2.14.24"]
+                 [com.scalar-labs/scalardb "2.4.0"
+                  :exclusions [software.amazon.awssdk/core]]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}}
   :jvm-opts ["-Djava.awt.headless=true"]

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -8,8 +8,9 @@
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.1"]
                  [cc.qbits/hayt "4.1.0"]
-                 [com.scalar-labs/scalardb "2.0.0" :exclusions [org.slf4j/slf4j-log4j12]]]
+                 [com.scalar-labs/scalardb "2.1.0" :exclusions [org.slf4j/slf4j-log4j12]]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}}
+  :jvm-opts ["-Djava.awt.headless=true"]
   :main scalardb.runner
   :aot [scalardb.runner])

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -1,0 +1,154 @@
+(ns scalardb.elle-append
+  (:require [clojure.string :as str]
+            [jepsen.checker :as checker]
+            [jepsen.client :as client]
+            [jepsen.generator :as gen]
+            [jepsen.tests.cycle.append :as append]
+            [cassandra.conductors :as cond]
+            [scalardb.core :as scalar])
+  (:import (com.scalar.db.api Consistency
+                              Get
+                              Put
+                              PutIfNotExists
+                              Result)
+           (com.scalar.db.io IntValue
+                             TextValue
+                             Key)
+           (com.scalar.db.exception.transaction CommitException
+                                                CrudException
+                                                UnknownTransactionStatusException)))
+
+(def ^:private ^:const KEYSPACE "jepsen")
+(def ^:private ^:const TABLE "txn")
+(def ^:private ^:const DEFAULT_TABLE_COUNT 3)
+(def ^:private ^:const SCHEMA {:id                     :int
+                               :sk                     :int
+                               :val                    :text
+                               :tx_id                  :text
+                               :tx_version             :int
+                               :tx_state               :int
+                               :tx_prepared_at         :bigint
+                               :tx_committed_at        :bigint
+                               :before_sk              :int
+                               :before_val             :text
+                               :before_tx_id           :text
+                               :before_tx_version      :int
+                               :before_tx_state        :int
+                               :before_tx_prepared_at  :bigint
+                               :before_tx_committed_at :bigint
+                               :primary-key [:id]})
+(def ^:private ^:const ID "id")
+(def ^:private ^:const SK "sk")
+(def ^:private ^:const VALUE "val")
+
+(defn- prepare-get
+  [table id]
+  (-> (Key. [(IntValue. ID id)])
+      (Get.)
+      (.forNamespace KEYSPACE)
+      (.forTable table)))
+
+(defn- prepare-put
+  [table id value insert?]
+  (let [put (-> (Key. [(IntValue. ID id)])
+                (Put.)
+                (.forNamespace KEYSPACE)
+                (.forTable table)
+                (.withValue (TextValue. VALUE value)))]
+    (if insert?
+      (-> put
+          (.withValue (IntValue. SK id))
+          (.withCondition (PutIfNotExists.)))
+      put)))
+
+(defn- get-value
+  [r]
+  (some-> r .get (.getValue VALUE) .get .getString .get))
+
+(defn- tx-insert
+  [tx table id value]
+  (.put tx (prepare-put table id value true)))
+
+(defn- tx-update
+  [tx table id prev value]
+  (.put tx (prepare-put table id (str prev "," value) false)))
+
+(defn- tx-execute
+  [tx [f k v]]
+  (let [table (str TABLE (mod (hash k) DEFAULT_TABLE_COUNT))]
+    [f k (case f
+           :r (let [result (.get tx (prepare-get table k))]
+                (when (.isPresent result)
+                  (mapv #(Long/valueOf %)
+                        (str/split (get-value result) #","))))
+           :append (let [v' (str v)
+                         result (.get tx (prepare-get table k))]
+                     (if (.isPresent result)
+                       (tx-update tx table k (get-value result) v')
+                       (tx-insert tx table k v'))
+                     v))]))
+
+(defrecord AppendClient [initialized?]
+  client/Client
+  (open! [_ _ _]
+    (AppendClient. initialized?))
+
+  (setup! [_ test]
+    (locking initialized?
+      (when (compare-and-set! initialized? false true)
+        (doseq [i (range DEFAULT_TABLE_COUNT)]
+          (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                  :table (str TABLE i)
+                                                  :schema SCHEMA}])
+          (scalar/prepare-transaction-service! test)))))
+
+  (invoke! [_ test op]
+    (let [tx (scalar/start-transaction test)
+          txn (:value op)]
+      (try
+        (let [txn' (mapv (partial tx-execute tx) txn)]
+          (.commit tx)
+          (assoc op :type :ok :value txn'))
+
+        (catch UnknownTransactionStatusException _
+          (swap! (:unknown-tx test) conj (.getId tx))
+          (assoc op :type :info :error [:unknown-tx-status (.getId tx)]))
+        (catch Exception e
+          (scalar/try-reconnection! test)
+          (assoc op :type :fail :error [:crud-error (.getMessage e)])))))
+
+  (close! [_ _])
+
+  (teardown! [_ test]
+    (scalar/close-all! test)))
+
+(defn- append-test
+  [opts]
+  (append/test {:key-count 10
+                :min-txn-length 1
+                :max-txn-length 10
+                :max-writes-per-key 10
+                :consistency-models [(:consistency-model opts)]}))
+
+(defn elle-append-test
+  [opts]
+  (merge (scalar/scalardb-test (str "elle-append-" (:suffix opts))
+                               {:unknown-tx (atom #{})
+                                :failures (atom 0)
+                                :generator (gen/phases
+                                            (->> (:generator (append-test opts))
+                                                 (gen/nemesis
+                                                  (cond/mix-failure-seq opts))
+                                                 (gen/time-limit
+                                                  (:time-limit opts))))
+                                :client (AppendClient. (atom false))
+                                :checker (checker/compose
+                                          {:clock
+                                           (checker/clock-plot)
+                                           :stats
+                                           (checker/stats)
+                                           :exceptions
+                                           (checker/unhandled-exceptions)
+                                           :workload
+                                           (:checker (append-test opts))})})
+         opts))

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -99,8 +99,8 @@
         (doseq [i (range DEFAULT_TABLE_COUNT)]
           (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
                                                   :table (str TABLE i)
-                                                  :schema SCHEMA}])
-          (scalar/prepare-transaction-service! test)))))
+                                                  :schema SCHEMA}]))
+        (scalar/prepare-transaction-service! test))))
 
   (invoke! [_ test op]
     (let [tx (scalar/start-transaction test)
@@ -112,10 +112,10 @@
 
         (catch UnknownTransactionStatusException _
           (swap! (:unknown-tx test) conj (.getId tx))
-          (assoc op :type :info :error [:unknown-tx-status (.getId tx)]))
+          (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
         (catch Exception e
           (scalar/try-reconnection! test)
-          (assoc op :type :fail :error [:crud-error (.getMessage e)])))))
+          (assoc op :type :fail :error {:crud-error (.getMessage e)})))))
 
   (close! [_ _])
 

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -8,15 +8,30 @@
              [core :as jepsen]
              [cli :as cli]]
             [scalardb.transfer]
-            [scalardb.transfer_append]))
+            [scalardb.transfer_append]
+            [scalardb.elle_append]))
 
 (def tests
   "A map of test names to test constructors."
   {"transfer"        scalardb.transfer/transfer-test
-   "transfer-append" scalardb.transfer-append/transfer-append-test})
+   "transfer-append" scalardb.transfer-append/transfer-append-test
+   "elle-append" scalardb.elle-append/elle-append-test})
 
 (def test-opt-spec
-  [(cli/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)])
+  [(cli/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)
+
+   [nil "--isolation-level ISOLATION_LEVEL" "isolation level"
+    :default :snapshot
+    :parse-fn keyword
+    :validate [#{:snapshot :serializable}
+               "Should be one of snapshot or serializable"]]
+
+   [nil "--serializable-strategy SERIALIZABLE_STRATEGY"
+    "serializable strategy"
+    :default :extra-write
+    :parse-fn keyword
+    :validate [#{:extra-write :extra-read}
+               "Should be one of extra-write or extra-read"]]])
 
 (defn test-cmd
   []

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -15,7 +15,7 @@
   "A map of test names to test constructors."
   {"transfer"        scalardb.transfer/transfer-test
    "transfer-append" scalardb.transfer-append/transfer-append-test
-   "elle-append" scalardb.elle-append/elle-append-test})
+   "elle-append"     scalardb.elle-append/elle-append-test})
 
 (def test-opt-spec
   [(cli/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)
@@ -31,7 +31,12 @@
     :default :extra-write
     :parse-fn keyword
     :validate [#{:extra-write :extra-read}
-               "Should be one of extra-write or extra-read"]]])
+               "Should be one of extra-write or extra-read"]]
+
+   [nil "--consistency-model CONSISTENCY_MODEL"
+    "consistency model to be checked"
+    :default :snapshot-isolation
+    :parse-fn keyword]])
 
 (defn test-cmd
   []

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -42,8 +42,8 @@
 (deftest create-properties-test
   (let [nodes ["n1" "n2" "n3"]
         properties (#'scalar/create-properties
-                     {:isolation-level :serializable
-                      :serializable-strategy :extra-write} nodes)]
+                    {:isolation-level :serializable
+                     :serializable-strategy :extra-write} nodes)]
     (is (= "n1,n2,n3"
            (.getProperty properties "scalar.db.contact_points")))
     (is (= "cassandra"

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -41,13 +41,19 @@
 
 (deftest create-properties-test
   (let [nodes ["n1" "n2" "n3"]
-        properties (#'scalar/create-properties nodes)]
+        properties (#'scalar/create-properties
+                     {:isolation-level :serializable
+                      :serializable-strategy :extra-write} nodes)]
     (is (= "n1,n2,n3"
            (.getProperty properties "scalar.db.contact_points")))
     (is (= "cassandra"
            (.getProperty properties "scalar.db.username")))
     (is (= "cassandra"
-           (.getProperty properties "scalar.db.password")))))
+           (.getProperty properties "scalar.db.password")))
+    (is (= "SERIALIZABLE"
+           (.getProperty properties "scalar.db.isolation_level")))
+    (is (= "EXTRA_WRITE"
+           (.getProperty properties "scalar.db.consensuscommit.serializable_strategy")))))
 
 (defn- mock-result
   "This is only for Coordinator/get and this returns ID as `tx_state`"

--- a/scalardb/test/scalardb/elle_append_test.clj
+++ b/scalardb/test/scalardb/elle_append_test.clj
@@ -1,0 +1,156 @@
+(ns scalardb.elle-append-test
+  (:require [clojure.test :refer :all]
+            [jepsen.client :as client]
+            [scalardb.core :as scalar]
+            [scalardb.elle-append :as elle-append]
+            [spy.core :as spy])
+  (:import (com.scalar.db.api DistributedTransaction)
+           (com.scalar.db.api Get
+                              Put
+                              Result)
+           (com.scalar.db.io IntValue
+                             Key
+                             TextValue)
+           (com.scalar.db.exception.transaction CommitException
+                                                CrudException
+                                                UnknownTransactionStatusException)
+           (java.util Optional)))
+
+(def ^:dynamic test-records (atom {0 {} 1 {} 2 {} 3 {} 4 {}}))
+
+(def ^:dynamic get-count (atom 0))
+(def ^:dynamic put-count (atom 0))
+(def ^:dynamic commit-count (atom 0))
+
+(defn- key->id
+  [^Key k]
+  (-> k .get first .get))
+
+(defn- mock-result
+  [id]
+  (reify
+    Result
+    (getValue [this column]
+      (if-let [v (get (@test-records id) (keyword column))]
+        (if (= "sk" column)
+          (->> v (IntValue. column) Optional/of)
+          (->> v (TextValue. column) Optional/of))
+        (Optional/empty)))))
+
+(defn- mock-get
+  [^Get g]
+  (let [id (-> g .getPartitionKey key->id)]
+    (swap! get-count inc)
+    (if (seq (@test-records id))
+      (Optional/of (mock-result id))
+      (Optional/empty))))
+
+(defn- mock-put
+  [^Put p]
+  (let [id (-> p .getPartitionKey key->id)
+        sk (some-> p .getValues (get "sk") .get)
+        v (some-> p .getValues (get "val") .getString .get)]
+    (if sk
+      (swap! test-records #(update % id assoc :sk sk :val v))
+      (swap! test-records #(update % id assoc :val v)))
+    (swap! put-count inc)))
+
+(def mock-transaction
+  (reify
+    DistributedTransaction
+    (^Optional get [this ^Get g] (mock-get g))
+    (^void put [this ^Put p] (mock-put p))
+    (^void commit [this] (swap! commit-count inc))))
+
+(def mock-transaction-throws-exception
+  (reify
+    DistributedTransaction
+    (^Optional get [this ^Get g] (throw (CrudException. "get failed")))
+    (^void put [this ^Put p] (throw (CrudException. "put failed")))
+    (^void commit [this] (throw (CommitException. "commit failed")))))
+
+(def mock-transaction-throws-unknown
+  (reify
+    DistributedTransaction
+    (getId [this] "unknown-state-tx")
+    (^Optional get [this ^Get g] (mock-get g))
+    (^void put [this ^Put p] (mock-put p))
+    (^void commit [this] (throw (UnknownTransactionStatusException. "unknown state")))))
+
+(deftest append-client-init-test
+  (with-redefs [scalar/setup-transaction-tables (spy/spy)
+                scalar/prepare-transaction-service! (spy/spy)]
+    (let [client (client/open! (elle-append/->AppendClient (atom false))
+                               nil nil)]
+      (client/setup! client nil)
+      (is (true? @(:initialized? client)))
+      (is (spy/called-n-times? scalar/setup-transaction-tables 3))
+      (is (spy/called-once? scalar/prepare-transaction-service!))
+
+        ;; setup isn't executed
+      (client/setup! client nil)
+      (is (spy/called-n-times? scalar/setup-transaction-tables 3)))))
+
+(deftest append-client-invoke-test
+  (binding [test-records (atom {0 {} 1 {} 2 {} 3 {} 4 {}})
+            get-count (atom 0)
+            put-count (atom 0)
+            commit-count (atom 0)]
+    (with-redefs [scalar/start-transaction (spy/stub mock-transaction)]
+      (let [client (client/open! (elle-append/->AppendClient (atom false))
+                                 nil nil)
+            result (client/invoke! client
+                                   {:isolation-level :serializable
+                                    :serializable-strategy :extra-write}
+                                   {:type :invoke
+                                    :f :txn
+                                    :value [[:r 1 nil]
+                                            [:append 1 0]
+                                            [:r 0 nil]
+                                            [:append 1 1]
+                                            [:append 3 0]]})]
+        (is (spy/called-once? scalar/start-transaction))
+        (is (= 5 @get-count))
+        (is (= 3 @put-count))
+        (is (= 1 @commit-count))
+        (is (= {0 {} 1 {:sk 1 :val "0,1"} 2 {} 3 {:sk 3 :val "0"} 4 {}}
+               @test-records))
+        (is (= :ok (:type result)))))))
+
+(deftest append-client-invoke-crud-exception-test
+  (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-exception)
+                scalar/try-reconnection! (spy/spy)]
+    (let [client (client/open! (elle-append/->AppendClient (atom false))
+                               nil nil)
+          result (client/invoke! client
+                                 {:isolation-level :serializable
+                                  :serializable-strategy :extra-write}
+                                 {:type :invoke
+                                  :f :txn
+                                  :value [[:r 1 nil]]})]
+      (is (spy/called-once? scalar/start-transaction))
+      (is (spy/called-once? scalar/try-reconnection!))
+      (is (= :fail (:type result))))))
+
+(deftest append-client-invoke-unknown-exception-test
+  (binding [get-count (atom 0)
+            put-count (atom 0)]
+    (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-unknown)
+                  scalar/try-reconnection! (spy/spy)]
+      (let [client (client/open! (elle-append/->AppendClient (atom false))
+                                 nil nil)
+            result (client/invoke! client
+                                   {:isolation-level :serializable
+                                    :serializable-strategy :extra-write
+                                    :unknown-tx (atom #{})}
+                                   {:type :invoke
+                                    :f :txn
+                                    :value [[:r 1 nil]
+                                            [:append 1 0]]})]
+        (is (spy/called-once? scalar/start-transaction))
+        (is (spy/not-called? scalar/try-reconnection!))
+        (is (= 2 @get-count))
+        (is (= 1 @put-count))
+        (is (= :info (:type result)))
+        (is (= "unknown-state-tx" (get-in result
+                                          [:error :unknown-tx-status])))))))

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [jepsen "0.2.1"]
                  [cassandra "0.1.0-SNAPSHOT"]
-                 [cc.qbits/alia "4.3.1"]
+                 [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}


### PR DESCRIPTION
To verify serializable transactions: https://scalar-labs.atlassian.net/browse/DLT-6513

The current Scalar DB (2.4.0) using snapshot isolation (also in the case using serializable) failed in this test because a transaction could read a different value after another transaction committed.
https://scalar-labs.atlassian.net/browse/DLT-7969