### PR TITLE
Remove sk column from elle-append

### DIFF
--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -6,30 +6,26 @@
             [jepsen.tests.cycle.append :as append]
             [cassandra.conductors :as cond]
             [scalardb.core :as scalar])
-  (:import (com.scalar.db.api Consistency
-                              Get
+  (:import (com.scalar.db.api Get
                               Put
                               PutIfNotExists
                               Result)
            (com.scalar.db.io IntValue
                              TextValue
                              Key)
-           (com.scalar.db.exception.transaction CommitException
-                                                CrudException
-                                                UnknownTransactionStatusException)))
+           (com.scalar.db.exception.transaction
+            UnknownTransactionStatusException)))
 
 (def ^:private ^:const KEYSPACE "jepsen")
 (def ^:private ^:const TABLE "txn")
 (def ^:private ^:const DEFAULT_TABLE_COUNT 3)
 (def ^:private ^:const SCHEMA {:id                     :int
-                               :sk                     :int
                                :val                    :text
                                :tx_id                  :text
                                :tx_version             :int
                                :tx_state               :int
                                :tx_prepared_at         :bigint
                                :tx_committed_at        :bigint
-                               :before_sk              :int
                                :before_val             :text
                                :before_tx_id           :text
                                :before_tx_version      :int
@@ -38,7 +34,6 @@
                                :before_tx_committed_at :bigint
                                :primary-key [:id]})
 (def ^:private ^:const ID "id")
-(def ^:private ^:const SK "sk")
 (def ^:private ^:const VALUE "val")
 
 (defn- prepare-get
@@ -57,7 +52,6 @@
                 (.withValue (TextValue. VALUE value)))]
     (if insert?
       (-> put
-          (.withValue (IntValue. SK id))
           (.withCondition (PutIfNotExists.)))
       put)))
 

--- a/scalardb/test/scalardb/elle_append_test.clj
+++ b/scalardb/test/scalardb/elle_append_test.clj
@@ -32,9 +32,7 @@
     Result
     (getValue [this column]
       (if-let [v (get (@test-records id) (keyword column))]
-        (if (= "sk" column)
-          (->> v (IntValue. column) Optional/of)
-          (->> v (TextValue. column) Optional/of))
+        (->> v (TextValue. column) Optional/of)
         (Optional/empty)))))
 
 (defn- mock-get
@@ -48,11 +46,8 @@
 (defn- mock-put
   [^Put p]
   (let [id (-> p .getPartitionKey key->id)
-        sk (some-> p .getValues (get "sk") .get)
         v (some-> p .getValues (get "val") .getString .get)]
-    (if sk
-      (swap! test-records #(update % id assoc :sk sk :val v))
-      (swap! test-records #(update % id assoc :val v)))
+    (swap! test-records #(update % id assoc :val v))
     (swap! put-count inc)))
 
 (def mock-transaction
@@ -113,7 +108,7 @@
         (is (= 5 @get-count))
         (is (= 3 @put-count))
         (is (= 1 @commit-count))
-        (is (= {0 {} 1 {:sk 1 :val "0,1"} 2 {} 3 {:sk 3 :val "0"} 4 {}}
+        (is (= {0 {} 1 {:val "0,1"} 2 {} 3 {:val "0"} 4 {}}
                @test-records))
         (is (= :ok (:type result)))))))
 


### PR DESCRIPTION
I found that `sk` column isn't required for the `elle-append` test though I referred to the existing test which added the column.