### PR TITLE
add write-read-test

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -8,7 +8,7 @@
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardb "2.4.0"
+             :use-released {:dependencies [[com.scalar-labs/scalardb "2.4.1"
                                             :exclusions [software.amazon.awssdk/core]]]}
              :use-jars {:dependencies [[com.google.inject/guice "4.2.0"]
                                        [com.google.guava/guava "24.1-jre"]]

--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -1,0 +1,145 @@
+(ns scalardb.elle-write-read
+  (:require [jepsen.checker :as checker]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen.client :as client]
+            [jepsen.generator :as gen]
+            [jepsen.tests.cycle.wr :as wr]
+            [cassandra.conductors :as cond]
+            [scalardb.core :as scalar])
+  (:import (com.scalar.db.api Get
+                              Put
+                              PutIfNotExists
+                              Result)
+           (com.scalar.db.io IntValue
+                             Key)
+           (com.scalar.db.exception.transaction
+            UnknownTransactionStatusException)))
+
+(def ^:private ^:const KEYSPACE "jepsen")
+(def ^:private ^:const TABLE "txn")
+(def ^:private ^:const DEFAULT_TABLE_COUNT 3)
+(def ^:private ^:const SCHEMA {:id                     :int
+                               :val                    :int
+                               :tx_id                  :text
+                               :tx_version             :int
+                               :tx_state               :int
+                               :tx_prepared_at         :bigint
+                               :tx_committed_at        :bigint
+                               :before_val             :int
+                               :before_tx_id           :text
+                               :before_tx_version      :int
+                               :before_tx_state        :int
+                               :before_tx_prepared_at  :bigint
+                               :before_tx_committed_at :bigint
+                               :primary-key [:id]})
+(def ^:private ^:const ID "id")
+(def ^:private ^:const VALUE "val")
+
+(defn- prepare-get
+  [table id]
+  (-> (Key. [(IntValue. ID id)])
+      (Get.)
+      (.forNamespace KEYSPACE)
+      (.forTable table)))
+
+(defn- prepare-put
+  [table id value insert?]
+  (let [put (-> (Key. [(IntValue. ID id)])
+                (Put.)
+                (.forNamespace KEYSPACE)
+                (.forTable table)
+                (.withValue (IntValue. VALUE value)))]
+    (if insert?
+      (.withCondition put (PutIfNotExists.))
+      put)))
+
+(defn- get-value
+  [r]
+  (some-> r .get (.getValue VALUE) .get .get long))
+
+(defn- tx-insert
+  [tx table id value]
+  (.put tx (prepare-put table id value true))
+  value)
+
+(defn- tx-update
+  [tx table id value]
+  (.put tx (prepare-put table id value false))
+  value)
+
+(defn- tx-execute
+  [tx [f k v]]
+  (let [table (str TABLE (mod (hash k) DEFAULT_TABLE_COUNT))
+        result (.get tx (prepare-get table k))]
+    [f k (case f
+           :r (when (.isPresent result) (get-value result))
+           :w (if (.isPresent result)
+                (tx-update tx table k v)
+                (tx-insert tx table k v)))]))
+
+(defrecord WriteReadClient [initialized?]
+  client/Client
+  (open! [_ _ _]
+    (WriteReadClient. initialized?))
+
+  (setup! [_ test]
+    (locking initialized?
+      (when (compare-and-set! initialized? false true)
+        (doseq [i (range DEFAULT_TABLE_COUNT)]
+          (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                  :table (str TABLE i)
+                                                  :schema SCHEMA}]))
+        (scalar/prepare-transaction-service! test))))
+
+  (invoke! [_ test op]
+    (let [tx (scalar/start-transaction test)
+          txn (:value op)]
+      (try
+        (let [txn' (mapv (partial tx-execute tx) txn)]
+          (.commit tx)
+          (assoc op :type :ok :value txn'))
+        (catch UnknownTransactionStatusException _
+          (swap! (:unknown-tx test) conj (.getId tx))
+          (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
+        (catch Exception e
+          (scalar/try-reconnection! test)
+          (assoc op :type :fail :error {:crud-error (.getMessage e)})))))
+
+  (close! [_ _])
+
+  (teardown! [_ test]
+    (scalar/close-all! test)))
+
+(defn- write-read-gen
+  []
+  (wr/gen {:key-count 10
+           :min-txn-length 1
+           :max-txn-length 10
+           :max-writes-per-key 10}))
+
+(defn- write-read-checker
+  [opts]
+  (wr/checker {:consistency-models [(:consistency-model opts)]}))
+
+(defn elle-write-read-test
+  [opts]
+  (merge (scalar/scalardb-test (str "elle-wr-" (:suffix opts))
+                               {:unknown-tx (atom #{})
+                                :failures (atom 0)
+                                :generator (gen/phases
+                                            (->> (write-read-gen)
+                                                 (gen/nemesis
+                                                  (cond/mix-failure-seq opts))
+                                                 (gen/time-limit
+                                                  (:time-limit opts))))
+                                :client (WriteReadClient. (atom false))
+                                :checker (checker/compose
+                                          {:clock
+                                           (checker/clock-plot)
+                                           :stats
+                                           (checker/stats)
+                                           :exceptions
+                                           (checker/unhandled-exceptions)
+                                           :workload
+                                           (write-read-checker opts)})})
+         opts))

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -9,13 +9,15 @@
              [cli :as cli]]
             [scalardb.transfer]
             [scalardb.transfer_append]
-            [scalardb.elle_append]))
+            [scalardb.elle_append]
+            [scalardb.elle_write_read]))
 
 (def tests
   "A map of test names to test constructors."
   {"transfer"        scalardb.transfer/transfer-test
    "transfer-append" scalardb.transfer-append/transfer-append-test
-   "elle-append"     scalardb.elle-append/elle-append-test})
+   "elle-append"     scalardb.elle-append/elle-append-test
+   "elle-write-read" scalardb.elle-write-read/elle-write-read-test})
 
 (def test-opt-spec
   [(cli/repeated-opt nil "--test NAME" "Test(s) to run" [] tests)

--- a/scalardb/test/scalardb/elle_write_read_test.clj
+++ b/scalardb/test/scalardb/elle_write_read_test.clj
@@ -1,0 +1,149 @@
+(ns scalardb.elle-write-read-test
+  (:require [clojure.test :refer :all]
+            [jepsen.client :as client]
+            [scalardb.core :as scalar]
+            [scalardb.elle-write-read :as elle-wr]
+            [spy.core :as spy])
+  (:import (com.scalar.db.api DistributedTransaction)
+           (com.scalar.db.api Get
+                              Put
+                              Result)
+           (com.scalar.db.io IntValue
+                             Key)
+           (com.scalar.db.exception.transaction CommitException
+                                                CrudException
+                                                UnknownTransactionStatusException)
+           (java.util Optional)))
+
+(def ^:dynamic test-records (atom {0 {} 1 {} 2 {} 3 {}}))
+
+(def ^:dynamic get-count (atom 0))
+(def ^:dynamic put-count (atom 0))
+(def ^:dynamic commit-count (atom 0))
+
+(defn- key->id
+  [^Key k]
+  (-> k .get first .get))
+
+(defn- mock-result
+  [id]
+  (reify
+    Result
+    (getValue [this column]
+      (if-let [v (get (@test-records id) (keyword column))]
+        (->> v (IntValue. column) Optional/of)
+        (Optional/empty)))))
+
+(defn- mock-get
+  [^Get g]
+  (let [id (-> g .getPartitionKey key->id)]
+    (swap! get-count inc)
+    (if (seq (@test-records id))
+      (Optional/of (mock-result id))
+      (Optional/empty))))
+
+(defn- mock-put
+  [^Put p]
+  (let [id (-> p .getPartitionKey key->id)
+        v (some-> p .getValues (get "val") .get)]
+    (swap! test-records #(update % id assoc :val v))
+    (swap! put-count inc)))
+
+(def mock-transaction
+  (reify
+    DistributedTransaction
+    (^Optional get [this ^Get g] (mock-get g))
+    (^void put [this ^Put p] (mock-put p))
+    (^void commit [this] (swap! commit-count inc))))
+
+(def mock-transaction-throws-exception
+  (reify
+    DistributedTransaction
+    (^Optional get [this ^Get g] (throw (CrudException. "get failed")))
+    (^void put [this ^Put p] (throw (CrudException. "put failed")))
+    (^void commit [this] (throw (CommitException. "commit failed")))))
+
+(def mock-transaction-throws-unknown
+  (reify
+    DistributedTransaction
+    (getId [this] "unknown-state-tx")
+    (^Optional get [this ^Get g] (mock-get g))
+    (^void put [this ^Put p] (mock-put p))
+    (^void commit [this] (throw (UnknownTransactionStatusException. "unknown state")))))
+
+(deftest write-read-client-init-test
+  (with-redefs [scalar/setup-transaction-tables (spy/spy)
+                scalar/prepare-transaction-service! (spy/spy)]
+    (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
+                               nil nil)]
+      (client/setup! client nil)
+      (is (true? @(:initialized? client)))
+      (is (spy/called-n-times? scalar/setup-transaction-tables 3))
+      (is (spy/called-once? scalar/prepare-transaction-service!))
+
+      ;; setup isn't executed
+      (client/setup! client nil)
+      (is (spy/called-n-times? scalar/setup-transaction-tables 3)))))
+
+(deftest write-read-client-invoke-test
+  (binding [test-records (atom {0 {} 1 {} 2 {} 3 {}})
+            get-count (atom 0)
+            put-count (atom 0)
+            commit-count (atom 0)]
+    (with-redefs [scalar/start-transaction (spy/stub mock-transaction)]
+      (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
+                                 nil nil)
+            result (client/invoke! client
+                                   {:isolation-level :serializable
+                                    :serializable-strategy :extra-write}
+                                   {:type :invoke
+                                    :f :txn
+                                    :value [[:r 1 nil]
+                                            [:w 1 1]
+                                            [:r 0 nil]
+                                            [:w 3 2]]})]
+        (is (spy/called-once? scalar/start-transaction))
+        (is (= 4 @get-count))
+        (is (= 2 @put-count))
+        (is (= 1 @commit-count))
+        (is (= {0 {} 1 {:val 1} 2 {} 3 {:val 2}}
+               @test-records))
+        (is (= :ok (:type result)))))))
+
+(deftest write-read-client-invoke-crud-exception-test
+  (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-exception)
+                scalar/try-reconnection! (spy/spy)]
+    (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
+                               nil nil)
+          result (client/invoke! client
+                                 {:isolation-level :serializable
+                                  :serializable-strategy :extra-write}
+                                 {:type :invoke
+                                  :f :txn
+                                  :value [[:r 1 nil]]})]
+      (is (spy/called-once? scalar/start-transaction))
+      (is (spy/called-once? scalar/try-reconnection!))
+      (is (= :fail (:type result))))))
+
+(deftest write-read-client-invoke-unknown-exception-test
+  (binding [get-count (atom 0)
+            put-count (atom 0)]
+    (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-unknown)
+                  scalar/try-reconnection! (spy/spy)]
+      (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
+                                 nil nil)
+            result (client/invoke! client
+                                   {:isolation-level :serializable
+                                    :serializable-strategy :extra-write
+                                    :unknown-tx (atom #{})}
+                                   {:type :invoke
+                                    :f :txn
+                                    :value [[:r 1 nil]
+                                            [:w 1 1]]})]
+        (is (spy/called-once? scalar/start-transaction))
+        (is (spy/not-called? scalar/try-reconnection!))
+        (is (= 2 @get-count))
+        (is (= 1 @put-count))
+        (is (= :info (:type result)))
+        (is (= "unknown-state-tx" (get-in result
+                                          [:error :unknown-tx-status])))))))


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6513
To add a new test with `jepsen.tests.cycle.wr`.

This test is simpler than `elle-append` test.
In the test, a transaction just inserts or updates the value of the `val` column instead of appending, and the check phase checks the consistency.