### PR TITLE
Fix to do fallback

### DIFF
--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -48,8 +48,10 @@
         (:value res)))))
 
 (defn retry-when-exception
-  [f args & fallback]
-  (retry-when-exception* RETRIES f args fallback))
+  ([f args]
+   (retry-when-exception f args nil))
+  ([f args fallback]
+   (retry-when-exception* RETRIES f args fallback)))
 
 (defn- create-client-properties
   [test]


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8313

When the JDK installation failed, a test failed because `fallback` wasn't executed.
The cause is that `fallback` is given as a vector.
I fixed it by giving `fallback` as it is.