### PR TITLE
Update scalar jepsen test with latest scalar dl

### DIFF
--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -10,7 +10,7 @@
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "2.1.0" :exclusions [log4j/log4j]]]}
+             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.0.1" :exclusions [log4j/log4j]]]}
              :use-jars {:dependencies [[org.bouncycastle/bcpkix-jdk15on "1.59"]
                                        [org.bouncycastle/bcprov-jdk15on "1.59"]
                                        [com.google.inject/guice "4.2.0"]
@@ -18,9 +18,9 @@
                                        [com.google.protobuf/protobuf-java-util "3.13.0"]
                                        [com.scalar-labs/scalar-admin "1.0.0"
                                         :exclusions [org.slf4j/slf4j-log4j12]]]
-                        :resource-paths ["resources/scalardl-java-client-sdk.jar"
-                                         "resources/common.jar"
-                                         "resources/rpc.jar"]}
+                        :resource-paths ["resources/scalardl-java-client-sdk*.jar"
+                                         "resources/common*.jar"
+                                         "resources/rpc*.jar"]}
              :default [:base :system :user :provided :dev :use-released]}
   :java-source-paths ["contract"]
   :main scalardl.runner

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -10,7 +10,7 @@
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.0.1" :exclusions [log4j/log4j]]]}
+             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.0.1" :exclusions [org.slf4j/slf4j-log4j12]]]}
              :use-jars {:dependencies [[org.bouncycastle/bcpkix-jdk15on "1.59"]
                                        [org.bouncycastle/bcprov-jdk15on "1.59"]
                                        [com.google.inject/guice "4.2.0"]

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -18,9 +18,9 @@
                                        [com.google.protobuf/protobuf-java-util "3.13.0"]
                                        [com.scalar-labs/scalar-admin "1.0.0"
                                         :exclusions [org.slf4j/slf4j-log4j12]]]
-                        :resource-paths ["resources/scalardl-java-client-sdk*.jar"
-                                         "resources/common*.jar"
-                                         "resources/rpc*.jar"]}
+                        :resource-paths ["resources/scalardl-java-client-sdk"
+                                         "resources/scalardl-common"
+                                         "resources/scalardl-rpc"]}
              :default [:base :system :user :provided :dev :use-released]}
   :java-source-paths ["contract"]
   :main scalardl.runner

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -18,9 +18,9 @@
                                        [com.google.protobuf/protobuf-java-util "3.13.0"]
                                        [com.scalar-labs/scalar-admin "1.0.0"
                                         :exclusions [org.slf4j/slf4j-log4j12]]]
-                        :resource-paths ["resources/scalardl-java-client-sdk"
-                                         "resources/scalardl-common"
-                                         "resources/scalardl-rpc"]}
+                        :resource-paths ["resources/scalardl-java-client-sdk.jar"
+                                         "resources/scalardl-common.jar"
+                                         "resources/scalardl-rpc.jar"]}
              :default [:base :system :user :provided :dev :use-released]}
   :java-source-paths ["contract"]
   :main scalardl.runner

--- a/scalardl/test/scalardl/cas_test.clj
+++ b/scalardl/test/scalardl/cas_test.clj
@@ -17,7 +17,7 @@
 (def ^:dynamic test-records (atom []))
 
 (def mock-client-service
-  (proxy [ClientService] [nil nil nil]
+  (proxy [ClientService] [nil nil nil nil]
     (registerCertificate [])
     (registerContract [_ _ _ _]
       (swap! contract-count inc)
@@ -30,7 +30,7 @@
                                 nil))))
 
 (def mock-client-service-throws-unknown-status
-  (proxy [ClientService] [nil nil nil]
+  (proxy [ClientService] [nil nil nil nil]
     (registerCertificate [])
     (registerContract [_ _ _ _]
       (swap! contract-count inc)
@@ -42,7 +42,7 @@
                                StatusCode/UNKNOWN_TRANSACTION_STATUS)))))
 
 (def mock-client-service-throws-database-error
-  (proxy [ClientService] [nil nil nil]
+  (proxy [ClientService] [nil nil nil nil]
     (registerCertificate [])
     (registerContract [_ _ _ _]
       (swap! contract-count inc)

--- a/scalardl/test/scalardl/transfer_test.clj
+++ b/scalardl/test/scalardl/transfer_test.clj
@@ -17,7 +17,7 @@
 (def ^:dynamic test-records (atom []))
 
 (def mock-client-service
-  (proxy [ClientService] [nil nil nil]
+  (proxy [ClientService] [nil nil nil nil]
     (registerCertificate [])
     (registerContract [_ _ _ _]
       (swap! contract-count inc)
@@ -31,7 +31,7 @@
                                 nil))))
 
 (def mock-failure-client-service
-  (proxy [ClientService] [nil nil nil]
+  (proxy [ClientService] [nil nil nil nil]
     (registerCertificate [])
     (registerContract [_ _ _ _]
       (swap! contract-count inc)


### PR DESCRIPTION
Scalar dl common, rpc and java client sdk are updated. 

Dependent PR: https://github.com/scalar-labs/scalar/pull/617