### PR TITLE
Correct the serializable strategy property name

### DIFF
--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -27,8 +27,8 @@
 (def ^:private ISOLATION_LEVELS {:snapshot "SNAPSHOT"
                                  :serializable "SERIALIZABLE"})
 
-(def ^:private SERIALIZABLE_STRATEGIES {:extra-write "EXTRA_WRITE"
-                                        :extra-read "EXTRA_READ"})
+(def ^:private SERIALIZABLE_STRATEGIES {:extra-read "EXTRA_READ"
+                                        :extra-write "EXTRA_WRITE"})
 
 (defn setup-transaction-tables
   [test schemata]
@@ -55,7 +55,7 @@
     (.setProperty "scalar.db.password" "cassandra")
     (.setProperty "scalar.db.isolation_level"
                   ((:isolation-level test) ISOLATION_LEVELS))
-    (.setProperty "scalar.db.consensuscommit.serializable_strategy"
+    (.setProperty "scalar.db.consensus_commit.serializable_strategy"
                   ((:serializable-strategy test) SERIALIZABLE_STRATEGIES))))
 
 (defn- close-storage!

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -30,10 +30,10 @@
 
    [nil "--serializable-strategy SERIALIZABLE_STRATEGY"
     "serializable strategy"
-    :default :extra-write
+    :default :extra-read
     :parse-fn keyword
-    :validate [#{:extra-write :extra-read}
-               "Should be one of extra-write or extra-read"]]
+    :validate [#{:extra-read :extra-write}
+               "Should be one of extra-read or extra-write"]]
 
    [nil "--consistency-model CONSISTENCY_MODEL"
     "consistency model to be checked"

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -53,7 +53,7 @@
     (is (= "SERIALIZABLE"
            (.getProperty properties "scalar.db.isolation_level")))
     (is (= "EXTRA_WRITE"
-           (.getProperty properties "scalar.db.consensuscommit.serializable_strategy")))))
+           (.getProperty properties "scalar.db.consensus_commit.serializable_strategy")))))
 
 (defn- mock-result
   "This is only for Coordinator/get and this returns ID as `tx_state`"


### PR DESCRIPTION
The serializable strategy property name is changed from Scalar DB 3.0. This PR changes it. Please take a look!