### PR TITLE
Apply `independent` to the elle tests

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -9,8 +9,12 @@
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
              :use-released {:dependencies [[com.scalar-labs/scalardb "3.2.0"
-                                            :exclusions [software.amazon.awssdk/core
-                                                         com.oracle.database.jdbc/ojdbc8-production]]]}
+                                            ;; avoid the netty dependency issue
+                                            :exclusions [software.amazon.awssdk/*
+                                                         com.oracle.database.jdbc/ojdbc8-production
+                                                         com.azure/azure-cosmos
+                                                         io.grpc/grpc-core
+                                                         com.scalar-labs/scalardb-rpc]]]}
              :use-jars {:dependencies [[com.google.inject/guice "4.2.0"]
                                        [com.google.guava/guava "24.1-jre"]]
                         :resource-paths ["resources/scalardb.jar"]}

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -1,8 +1,10 @@
 (ns scalardb.elle-append
   (:require [clojure.string :as str]
+            [clojure.tools.logging :refer [debug info warn]]
             [jepsen.checker :as checker]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
+            [jepsen.independent :as independent]
             [jepsen.tests.cycle.append :as append]
             [cassandra.conductors :as cond]
             [scalardb.core :as scalar])
@@ -16,6 +18,7 @@
 
 (def ^:private ^:const KEYSPACE "jepsen")
 (def ^:private ^:const TABLE "txn")
+(def ^:private ^:const NUM_TABLE_ID_COUNT 2)
 (def ^:private ^:const DEFAULT_TABLE_COUNT 3)
 (def ^:private ^:const SCHEMA {:id                     :int
                                :val                    :text
@@ -62,8 +65,8 @@
   (.put tx (prepare-put table id (str prev "," value))))
 
 (defn- tx-execute
-  [tx [f k v]]
-  (let [table (str TABLE (mod (hash k) DEFAULT_TABLE_COUNT))]
+  [seq-id tx [f k v]]
+  (let [table (str TABLE seq-id \_ (mod (hash k) DEFAULT_TABLE_COUNT))]
     [f k (case f
            :r (let [result (.get tx (prepare-get table k))]
                 (when (.isPresent result)
@@ -76,6 +79,21 @@
                        (tx-insert tx table k v'))
                      v))]))
 
+(defn- add-tables
+  [test next-id]
+  (let [current-id @(:table-id test)]
+    (when (< current-id next-id)
+      (locking (:table-id test)
+        (when (compare-and-set! (:table-id test) current-id next-id)
+          (info (str "Creating new tables for " next-id))
+          (doseq [i (range DEFAULT_TABLE_COUNT)]
+            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                    :table (str TABLE
+                                                                next-id
+                                                                \_
+                                                                i)
+                                                    :schema SCHEMA}])))))))
+
 (defrecord AppendClient [initialized?]
   client/Client
   (open! [_ _ _]
@@ -84,20 +102,23 @@
   (setup! [_ test]
     (locking initialized?
       (when (compare-and-set! initialized? false true)
-        (doseq [i (range DEFAULT_TABLE_COUNT)]
+        (doseq [id (range NUM_TABLE_ID_COUNT)
+                i (range DEFAULT_TABLE_COUNT)]
           (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                  :table (str TABLE i)
+                                                  :table (str TABLE id \_ i)
                                                   :schema SCHEMA}]))
         (scalar/prepare-transaction-service! test))))
 
   (invoke! [_ test op]
     (let [tx (scalar/start-transaction test)
-          txn (:value op)]
+          [seq-id txn] (:value op)]
+      (when-not (> @(:table-id test) seq-id)
+        ;; add tables for the next sequence
+        (add-tables test (inc seq-id)))
       (try
-        (let [txn' (mapv (partial tx-execute tx) txn)]
+        (let [txn' (mapv (partial tx-execute seq-id tx) txn)]
           (.commit tx)
-          (assoc op :type :ok :value txn'))
-
+          (assoc op :type :ok :value (independent/tuple seq-id txn')))
         (catch UnknownTransactionStatusException _
           (swap! (:unknown-tx test) conj (.getId tx))
           (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
@@ -120,23 +141,26 @@
 
 (defn elle-append-test
   [opts]
-  (merge (scalar/scalardb-test (str "elle-append-" (:suffix opts))
-                               {:unknown-tx (atom #{})
-                                :failures (atom 0)
-                                :generator (gen/phases
-                                            (->> (:generator (append-test opts))
-                                                 (gen/nemesis
-                                                  (cond/mix-failure-seq opts))
-                                                 (gen/time-limit
-                                                  (:time-limit opts))))
-                                :client (AppendClient. (atom false))
-                                :checker (checker/compose
-                                          {:clock
-                                           (checker/clock-plot)
-                                           :stats
-                                           (checker/stats)
-                                           :exceptions
-                                           (checker/unhandled-exceptions)
-                                           :workload
-                                           (:checker (append-test opts))})})
+  (merge (scalar/scalardb-test
+          (str "elle-append-" (:suffix opts))
+          {:table-id (atom (dec NUM_TABLE_ID_COUNT))
+           :unknown-tx (atom #{})
+           :failures (atom 0)
+           :generator (->> (independent/concurrent-generator
+                            (:concurrency opts)
+                            (range)
+                            (fn [_]
+                              (->> (:generator (append-test opts))
+                                   (gen/limit 100)
+                                   (gen/process-limit
+                                    (:concurrency opts)))))
+                           (gen/nemesis
+                            (cond/mix-failure-seq opts))
+                           (gen/time-limit (:time-limit opts)))
+           :client (AppendClient. (atom false))
+           :checker (independent/checker
+                     (checker/compose
+                      {:stats (checker/stats)
+                       :exceptions (checker/unhandled-exceptions)
+                       :workload (:checker (append-test opts))}))})
          opts))

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -1,6 +1,6 @@
 (ns scalardb.elle-append
   (:require [clojure.string :as str]
-            [clojure.tools.logging :refer [debug info warn]]
+            [clojure.tools.logging :refer [info]]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.independent :as independent]

--- a/scalardb/src/scalardb/elle_append_2pc.clj
+++ b/scalardb/src/scalardb/elle_append_2pc.clj
@@ -1,8 +1,9 @@
 (ns scalardb.elle-append-2pc
   (:require [clojure.string :as str]
-            [jepsen.checker :as checker]
+            [clojure.tools.logging :refer [info]]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
+            [jepsen.independent :as independent]
             [jepsen.tests.cycle.append :as append]
             [cassandra.conductors :as cond]
             [scalardb.core :as scalar])
@@ -16,6 +17,7 @@
 
 (def ^:private ^:const KEYSPACE "jepsen")
 (def ^:private ^:const TABLE "txn")
+(def ^:private ^:const NUM_TABLE_ID_COUNT 2)
 (def ^:private ^:const DEFAULT_TABLE_COUNT 3)
 (def ^:private ^:const SCHEMA {:id                     :int
                                :val                    :text
@@ -62,9 +64,9 @@
   (.put tx (prepare-put table id (str prev "," value))))
 
 (defn- tx-execute
-  [tx1 tx2 [f k v]]
+  [seq-id tx1 tx2 [f k v]]
   (let [key_hash (hash k)
-        table (str TABLE (mod key_hash DEFAULT_TABLE_COUNT))
+        table (str TABLE seq-id \_ (mod key_hash DEFAULT_TABLE_COUNT))
         tx (if (= (mod key_hash 2) 0) tx1 tx2)
         result (.get tx (prepare-get table k))]
     [f k (case f
@@ -76,6 +78,21 @@
                        (tx-insert tx table k v'))
                      v))]))
 
+(defn- add-tables
+  [test next-id]
+  (let [current-id @(:table-id test)]
+    (when (< current-id next-id)
+      (locking (:table-id test)
+        (when (compare-and-set! (:table-id test) current-id next-id)
+          (info (str "Creating new tables for " next-id))
+          (doseq [i (range DEFAULT_TABLE_COUNT)]
+            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                    :table (str TABLE
+                                                                next-id
+                                                                \_
+                                                                i)
+                                                    :schema SCHEMA}])))))))
+
 (defrecord AppendClient [initialized?]
   client/Client
   (open! [_ _ _]
@@ -84,25 +101,29 @@
   (setup! [_ test]
     (locking initialized?
       (when (compare-and-set! initialized? false true)
-        (doseq [i (range DEFAULT_TABLE_COUNT)]
+        (doseq [id (range NUM_TABLE_ID_COUNT)
+                i (range DEFAULT_TABLE_COUNT)]
           (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                  :table (str TABLE i)
+                                                  :table (str TABLE id \_ i)
                                                   :schema SCHEMA}]))
         (scalar/prepare-2pc-service! test))))
 
   (invoke! [_ test op]
     (let [tx1 (scalar/start-2pc test)
           tx2 (scalar/join-2pc test (.getId tx1))
-          txn (:value op)]
+          [seq-id txn] (:value op)]
+      (when (<= @(:table-id test) seq-id)
+        ;; add tables for the next sequence
+        (add-tables test (inc seq-id)))
       (try
-        (let [txn' (mapv (partial tx-execute tx1 tx2) txn)]
+        (let [txn' (mapv (partial tx-execute seq-id tx1 tx2) txn)]
           (.prepare tx1)
           (.prepare tx2)
           (.validate tx1)
           (.validate tx2)
           (.commit tx1)
           (.commit tx2)
-          (assoc op :type :ok :value txn'))
+          (assoc op :type :ok :value (independent/tuple seq-id txn')))
         (catch UnknownTransactionStatusException _
           (swap! (:unknown-tx test) conj (.getId tx1))
           (assoc op :type :info :error {:unknown-tx-status (.getId tx1)}))
@@ -127,23 +148,22 @@
 
 (defn elle-append-2pc-test
   [opts]
-  (merge (scalar/scalardb-test (str "elle-append-2pc-" (:suffix opts))
-                               {:unknown-tx (atom #{})
-                                :failures (atom 0)
-                                :generator (gen/phases
-                                            (->> (:generator (append-test opts))
-                                                 (gen/nemesis
-                                                  (cond/mix-failure-seq opts))
-                                                 (gen/time-limit
-                                                  (:time-limit opts))))
-                                :client (AppendClient. (atom false))
-                                :checker (checker/compose
-                                          {:clock
-                                           (checker/clock-plot)
-                                           :stats
-                                           (checker/stats)
-                                           :exceptions
-                                           (checker/unhandled-exceptions)
-                                           :workload
-                                           (:checker (append-test opts))})})
+  (merge (scalar/scalardb-test
+          (str "elle-append-2pc-" (:suffix opts))
+          {:table-id (atom (dec NUM_TABLE_ID_COUNT))
+           :unknown-tx (atom #{})
+           :failures (atom 0)
+           :generator (->> (independent/concurrent-generator
+                            (:concurrency opts)
+                            (range)
+                            (fn [_]
+                              (->> (:generator (append-test opts))
+                                   (gen/limit 100)
+                                   (gen/process-limit
+                                    (:concurrency opts)))))
+                           (gen/nemesis
+                            (cond/mix-failure-seq opts))
+                           (gen/time-limit (:time-limit opts)))
+           :client (AppendClient. (atom false))
+           :checker (scalar/independent-checker (:checker (append-test opts)))})
          opts))

--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -1,5 +1,5 @@
 (ns scalardb.elle-write-read
-  (:require [clojure.tools.logging :refer [debug info warn]]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.independent :as independent]

--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -1,5 +1,5 @@
 (ns scalardb.elle-write-read
-  (:require [jepsen.checker :as checker]
+  (:require [clojure.tools.logging :refer [debug info warn]]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.independent :as independent]
@@ -148,9 +148,5 @@
                             (cond/mix-failure-seq opts))
                            (gen/time-limit (:time-limit opts)))
            :client (WriteReadClient. (atom false))
-           :checker (independent/checker
-                     (checker/compose
-                      {:stats (checker/stats)
-                       :exceptions (checker/unhandled-exceptions)
-                       :workload (write-read-checker opts)}))})
+           :checker (scalar/independent-checker (write-read-checker opts))})
          opts))

--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -2,6 +2,7 @@
   (:require [jepsen.checker :as checker]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
+            [jepsen.independent :as independent]
             [jepsen.tests.cycle.wr :as wr]
             [cassandra.conductors :as cond]
             [scalardb.core :as scalar])
@@ -14,6 +15,7 @@
 
 (def ^:private ^:const KEYSPACE "jepsen")
 (def ^:private ^:const TABLE "txn")
+(def ^:private ^:const NUM_TABLE_ID_COUNT 2)
 (def ^:private ^:const DEFAULT_TABLE_COUNT 3)
 (def ^:private ^:const SCHEMA {:id                     :int
                                :val                    :int
@@ -57,12 +59,27 @@
   value)
 
 (defn- tx-execute
-  [tx [f k v]]
-  (let [table (str TABLE (mod (hash k) DEFAULT_TABLE_COUNT))
+  [seq-id tx [f k v]]
+  (let [table (str TABLE seq-id \_ (mod (hash k) DEFAULT_TABLE_COUNT))
         result (.get tx (prepare-get table k))]
     [f k (case f
            :r (when (.isPresent result) (get-value result))
            :w (tx-write tx table k v))]))
+
+(defn- add-tables
+  [test next-id]
+  (let [current-id @(:table-id test)]
+    (when (< current-id next-id)
+      (locking (:table-id test)
+        (when (compare-and-set! (:table-id test) current-id next-id)
+          (info (str "Creating new tables for " next-id))
+          (doseq [i (range DEFAULT_TABLE_COUNT)]
+            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                    :table (str TABLE
+                                                                next-id
+                                                                \_
+                                                                i)
+                                                    :schema SCHEMA}])))))))
 
 (defrecord WriteReadClient [initialized?]
   client/Client
@@ -72,19 +89,23 @@
   (setup! [_ test]
     (locking initialized?
       (when (compare-and-set! initialized? false true)
-        (doseq [i (range DEFAULT_TABLE_COUNT)]
+        (doseq [id (range NUM_TABLE_ID_COUNT)
+                i (range DEFAULT_TABLE_COUNT)]
           (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                  :table (str TABLE i)
+                                                  :table (str TABLE id \_ i)
                                                   :schema SCHEMA}]))
         (scalar/prepare-transaction-service! test))))
 
   (invoke! [_ test op]
     (let [tx (scalar/start-transaction test)
-          txn (:value op)]
+          [seq-id txn] (:value op)]
+      (when (<= @(:table-id test) seq-id)
+        ;; add tables for the next sequence
+        (add-tables test (inc seq-id)))
       (try
-        (let [txn' (mapv (partial tx-execute tx) txn)]
+        (let [txn' (mapv (partial tx-execute seq-id tx) txn)]
           (.commit tx)
-          (assoc op :type :ok :value txn'))
+          (assoc op :type :ok :value (independent/tuple seq-id txn')))
         (catch UnknownTransactionStatusException _
           (swap! (:unknown-tx test) conj (.getId tx))
           (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
@@ -110,23 +131,26 @@
 
 (defn elle-write-read-test
   [opts]
-  (merge (scalar/scalardb-test (str "elle-wr-" (:suffix opts))
-                               {:unknown-tx (atom #{})
-                                :failures (atom 0)
-                                :generator (gen/phases
-                                            (->> (write-read-gen)
-                                                 (gen/nemesis
-                                                  (cond/mix-failure-seq opts))
-                                                 (gen/time-limit
-                                                  (:time-limit opts))))
-                                :client (WriteReadClient. (atom false))
-                                :checker (checker/compose
-                                          {:clock
-                                           (checker/clock-plot)
-                                           :stats
-                                           (checker/stats)
-                                           :exceptions
-                                           (checker/unhandled-exceptions)
-                                           :workload
-                                           (write-read-checker opts)})})
+  (merge (scalar/scalardb-test
+          (str "elle-wr-" (:suffix opts))
+          {:table-id (atom (dec NUM_TABLE_ID_COUNT))
+           :unknown-tx (atom #{})
+           :failures (atom 0)
+           :generator (->> (independent/concurrent-generator
+                            (:concurrency opts)
+                            (range)
+                            (fn [_]
+                              (->> write-read-gen
+                                   (gen/limit 100)
+                                   (gen/process-limit
+                                    (:concurrency opts)))))
+                           (gen/nemesis
+                            (cond/mix-failure-seq opts))
+                           (gen/time-limit (:time-limit opts)))
+           :client (WriteReadClient. (atom false))
+           :checker (independent/checker
+                     (checker/compose
+                      {:stats (checker/stats)
+                       :exceptions (checker/unhandled-exceptions)
+                       :workload (write-read-checker opts)}))})
          opts))

--- a/scalardb/src/scalardb/elle_write_read_2pc.clj
+++ b/scalardb/src/scalardb/elle_write_read_2pc.clj
@@ -1,7 +1,8 @@
 (ns scalardb.elle-write-read-2pc
-  (:require [jepsen.checker :as checker]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
+            [jepsen.independent :as independent]
             [jepsen.tests.cycle.wr :as wr]
             [cassandra.conductors :as cond]
             [scalardb.core :as scalar])
@@ -14,6 +15,7 @@
 
 (def ^:private ^:const KEYSPACE "jepsen")
 (def ^:private ^:const TABLE "txn")
+(def ^:private ^:const NUM_TABLE_ID_COUNT 2)
 (def ^:private ^:const DEFAULT_TABLE_COUNT 3)
 (def ^:private ^:const SCHEMA {:id                     :int
                                :val                    :int
@@ -57,14 +59,29 @@
   value)
 
 (defn- tx-execute
-  [tx1 tx2 [f k v]]
+  [seq-id tx1 tx2 [f k v]]
   (let [key_hash (hash k)
-        table (str TABLE (mod key_hash DEFAULT_TABLE_COUNT))
+        table (str TABLE seq-id \_ (mod key_hash DEFAULT_TABLE_COUNT))
         tx (if (= (mod key_hash 2) 0) tx1 tx2)
         result (.get tx (prepare-get table k))]
     [f k (case f
            :r (when (.isPresent result) (get-value result))
            :w (tx-write tx table k v))]))
+
+(defn- add-tables
+  [test next-id]
+  (let [current-id @(:table-id test)]
+    (when (< current-id next-id)
+      (locking (:table-id test)
+        (when (compare-and-set! (:table-id test) current-id next-id)
+          (info (str "Creating new tables for " next-id))
+          (doseq [i (range DEFAULT_TABLE_COUNT)]
+            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                    :table (str TABLE
+                                                                next-id
+                                                                \_
+                                                                i)
+                                                    :schema SCHEMA}])))))))
 
 (defrecord WriteReadClient [initialized?]
   client/Client
@@ -74,25 +91,29 @@
   (setup! [_ test]
     (locking initialized?
       (when (compare-and-set! initialized? false true)
-        (doseq [i (range DEFAULT_TABLE_COUNT)]
+        (doseq [id (range NUM_TABLE_ID_COUNT)
+                i (range DEFAULT_TABLE_COUNT)]
           (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                  :table (str TABLE i)
+                                                  :table (str TABLE id \_ i)
                                                   :schema SCHEMA}]))
         (scalar/prepare-2pc-service! test))))
 
   (invoke! [_ test op]
     (let [tx1 (scalar/start-2pc test)
           tx2 (scalar/join-2pc test (.getId tx1))
-          txn (:value op)]
+          [seq-id txn] (:value op)]
+      (when (<= @(:table-id test) seq-id)
+        ;; add tables for the next sequence
+        (add-tables test (inc seq-id)))
       (try
-        (let [txn' (mapv (partial tx-execute tx1 tx2) txn)]
+        (let [txn' (mapv (partial tx-execute seq-id tx1 tx2) txn)]
           (.prepare tx1)
           (.prepare tx2)
           (.validate tx1)
           (.validate tx2)
           (.commit tx1)
           (.commit tx2)
-          (assoc op :type :ok :value txn'))
+          (assoc op :type :ok :value (independent/tuple seq-id txn')))
         (catch UnknownTransactionStatusException _
           (swap! (:unknown-tx test) conj (.getId tx1))
           (assoc op :type :info :error {:unknown-tx-status (.getId tx1)}))
@@ -120,23 +141,22 @@
 
 (defn elle-write-read-2pc-test
   [opts]
-  (merge (scalar/scalardb-test (str "elle-wr-2pc-" (:suffix opts))
-                               {:unknown-tx (atom #{})
-                                :failures (atom 0)
-                                :generator (gen/phases
-                                            (->> (write-read-gen)
-                                                 (gen/nemesis
-                                                  (cond/mix-failure-seq opts))
-                                                 (gen/time-limit
-                                                  (:time-limit opts))))
-                                :client (WriteReadClient. (atom false))
-                                :checker (checker/compose
-                                          {:clock
-                                           (checker/clock-plot)
-                                           :stats
-                                           (checker/stats)
-                                           :exceptions
-                                           (checker/unhandled-exceptions)
-                                           :workload
-                                           (write-read-checker opts)})})
+  (merge (scalar/scalardb-test
+          (str "elle-wr-2pc-" (:suffix opts))
+          {:table-id (atom (dec NUM_TABLE_ID_COUNT))
+           :unknown-tx (atom #{})
+           :failures (atom 0)
+           :generator (->> (independent/concurrent-generator
+                            (:concurrency opts)
+                            (range)
+                            (fn [_]
+                              (->> write-read-gen
+                                   (gen/limit 100)
+                                   (gen/process-limit
+                                    (:concurrency opts)))))
+                           (gen/nemesis
+                            (cond/mix-failure-seq opts))
+                           (gen/time-limit (:time-limit opts)))
+           :client (WriteReadClient. (atom false))
+           :checker (scalar/independent-checker (write-read-checker opts))})
          opts))

--- a/scalardb/test/scalardb/elle_write_read_2pc_test.clj
+++ b/scalardb/test/scalardb/elle_write_read_2pc_test.clj
@@ -94,12 +94,12 @@
                                nil nil)]
       (client/setup! client nil)
       (is (true? @(:initialized? client)))
-      (is (spy/called-n-times? scalar/setup-transaction-tables 3))
+      (is (spy/called-n-times? scalar/setup-transaction-tables 6))
       (is (spy/called-once? scalar/prepare-2pc-service!))
 
       ;; setup isn't executed
       (client/setup! client nil)
-      (is (spy/called-n-times? scalar/setup-transaction-tables 3)))))
+      (is (spy/called-n-times? scalar/setup-transaction-tables 6)))))
 
 (deftest write-read-client-invoke-test
   (binding [test-records (atom {0 {} 1 {} 2 {} 3 {}})
@@ -114,13 +114,15 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write}
+                                    :serializable-strategy :extra-write
+                                    :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
-                                    :value [[:r 1 nil]
-                                            [:w 1 1]
-                                            [:r 0 nil]
-                                            [:w 3 2]]})]
+                                    :value [0
+                                            [[:r 1 nil]
+                                             [:w 1 1]
+                                             [:r 0 nil]
+                                             [:w 3 2]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
         (is (= 4 @get-count))
@@ -141,10 +143,11 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write}
+                                    :serializable-strategy :extra-write
+                                    :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
-                                    :value [[:r 1 nil]]})]
+                                    :value [0 [[:r 1 nil]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
         (is (spy/called-once? scalar/try-reconnection-for-2pc!))
@@ -165,11 +168,11 @@
             result (client/invoke! client
                                    {:isolation-level :serializable
                                     :serializable-strategy :extra-write
+                                    :table-id (atom 1)
                                     :unknown-tx (atom #{})}
                                    {:type :invoke
                                     :f :txn
-                                    :value [[:r 1 nil]
-                                            [:w 1 1]]})]
+                                    :value [0 [[:r 1 nil] [:w 1 1]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
         (is (spy/not-called? scalar/try-reconnection-for-2pc!))


### PR DESCRIPTION
To avoid the OOM issue and make the running time short, I applied `independent` to the Elle tests.
An `independent` test increments the sequence number per a fixed number of transactions. The test adds tables in advance during the execution and makes transactions of the next sequence access the new tables.

We could refactor almost the same functions. I'll do that in another PR.