### PR TITLE
catch failure of adding tables

### DIFF
--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -111,10 +111,10 @@
   (invoke! [_ test op]
     (let [tx (scalar/start-transaction test)
           [seq-id txn] (:value op)]
-      (when (<= @(:table-id test) seq-id)
-        ;; add tables for the next sequence
-        (add-tables test (inc seq-id)))
       (try
+        (when (<= @(:table-id test) seq-id)
+          ;; add tables for the next sequence
+          (add-tables test (inc seq-id)))
         (let [txn' (mapv (partial tx-execute seq-id tx) txn)]
           (.commit tx)
           (assoc op :type :ok :value (independent/tuple seq-id txn')))

--- a/scalardb/src/scalardb/elle_append_2pc.clj
+++ b/scalardb/src/scalardb/elle_append_2pc.clj
@@ -112,10 +112,10 @@
     (let [tx1 (scalar/start-2pc test)
           tx2 (scalar/join-2pc test (.getId tx1))
           [seq-id txn] (:value op)]
-      (when (<= @(:table-id test) seq-id)
-        ;; add tables for the next sequence
-        (add-tables test (inc seq-id)))
       (try
+        (when (<= @(:table-id test) seq-id)
+          ;; add tables for the next sequence
+          (add-tables test (inc seq-id)))
         (let [txn' (mapv (partial tx-execute seq-id tx1 tx2) txn)]
           (.prepare tx1)
           (.prepare tx2)

--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -99,10 +99,10 @@
   (invoke! [_ test op]
     (let [tx (scalar/start-transaction test)
           [seq-id txn] (:value op)]
-      (when (<= @(:table-id test) seq-id)
-        ;; add tables for the next sequence
-        (add-tables test (inc seq-id)))
       (try
+        (when (<= @(:table-id test) seq-id)
+          ;; add tables for the next sequence
+          (add-tables test (inc seq-id)))
         (let [txn' (mapv (partial tx-execute seq-id tx) txn)]
           (.commit tx)
           (assoc op :type :ok :value (independent/tuple seq-id txn')))

--- a/scalardb/src/scalardb/elle_write_read_2pc.clj
+++ b/scalardb/src/scalardb/elle_write_read_2pc.clj
@@ -102,10 +102,10 @@
     (let [tx1 (scalar/start-2pc test)
           tx2 (scalar/join-2pc test (.getId tx1))
           [seq-id txn] (:value op)]
-      (when (<= @(:table-id test) seq-id)
-        ;; add tables for the next sequence
-        (add-tables test (inc seq-id)))
       (try
+        (when (<= @(:table-id test) seq-id)
+          ;; add tables for the next sequence
+          (add-tables test (inc seq-id)))
         (let [txn' (mapv (partial tx-execute seq-id tx1 tx2) txn)]
           (.prepare tx1)
           (.prepare tx2)


### PR DESCRIPTION
When table creation failure happened in Elle tests, the exception wasn't caught in the `invoke!` operation and the error couldn't be understood by the result writer.

The exception for table creation failure should be caught and return the `op` with the error message in the `invoke!`.