### PR TITLE
Fix read record for checker

### DIFF
--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -142,6 +142,11 @@
   [test]
   (prepare-service! test :2pc))
 
+(defn check-storage-connection!
+  [test]
+  (when-not @(:storage test)
+    (prepare-storage-service! test)))
+
 (defn check-transaction-connection!
   [test]
   (when-not @(:transaction test)

--- a/scalardb/src/scalardb/transfer_2pc.clj
+++ b/scalardb/src/scalardb/transfer_2pc.clj
@@ -14,6 +14,7 @@
                               Result)
            (com.scalar.db.io IntValue
                              Key)
+           (com.scalar.db.exception.storage ExecutionException)
            (com.scalar.db.exception.transaction CrudException
                                                 UnknownTransactionStatusException)))
 
@@ -117,17 +118,20 @@
 
 (defn- read-record
   "Read a record with a transaction. If read fails, this function returns nil."
-  [tx i]
+  [tx storage i]
   (try
     (.get tx (prepare-get i))
-    (catch CrudException _ nil)))
+    (.get storage (prepare-get i))
+    (catch CrudException _ nil)
+    (catch ExecutionException _ nil)))
 
 (defn- read-all-with-retry
   [test n]
   (scalar/check-transaction-connection! test)
-  (scalar/with-retry scalar/prepare-transaction-service! test
+  (scalar/check-storage-connection! test)
+  (scalar/with-retry (fn [test] (scalar/prepare-transaction-service! test) (scalar/prepare-storage-service! test)) test
     (let [tx (scalar/start-transaction test)
-          results (map #(read-record tx %) (range n))]
+          results (map #(read-record tx @(:storage test) %) (range n))]
       (if (some nil? results) nil results))))
 
 (defrecord TransferClient [initialized? n initial-balance]

--- a/scalardb/test/scalardb/transfer_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_2pc_test.clj
@@ -7,6 +7,7 @@
             [scalardb.transfer-2pc :as transfer]
             [spy.core :as spy])
   (:import (com.scalar.db.api DistributedTransaction
+                              DistributedStorage
                               TwoPhaseCommitTransaction
                               Get
                               Put
@@ -60,6 +61,12 @@
     (^Optional get [this ^Get g] (mock-get g))
     (^void put [this ^Put p] (mock-put p))
     (^void commit [this] (swap! commit-count inc))))
+
+(def mock-storage
+  (reify
+    DistributedStorage
+    (^Optional get [this ^Get g] (mock-get g))
+    (^void put [this ^Put p] (mock-put p))))
 
 (def mock-transaction-throws-exception
   (reify
@@ -198,30 +205,35 @@
 (deftest transfer-client-get-all-test
   (binding [test-records (atom {0 1000 1 100 2 10 3 1 4 0})]
     (with-redefs [scalar/check-transaction-connection! (spy/spy)
+                  scalar/check-storage-connection! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
       (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
                                  nil nil)
-            result (client/invoke! client {}
+            result (client/invoke! client {:storage (ref mock-storage)}
                                    (#'transfer/get-all {:client client}
                                                        nil))]
         (is (spy/called-once? scalar/check-transaction-connection!))
+        (is (spy/called-once? scalar/check-storage-connection!))
         (is (= :ok (:type result)))
         (is (= [1000 100 10 1 0] (get-in result [:value :balance])))
         (is (= [1000 100 10 1 0] (get-in result [:value :version])))))))
 
 (deftest transfer-client-get-all-fail-test
   (with-redefs [scalar/check-transaction-connection! (spy/spy)
+                scalar/check-storage-connection! (spy/spy)
                 cass/exponential-backoff (spy/spy)
                 scalar/prepare-transaction-service! (spy/spy)
+                scalar/prepare-storage-service! (spy/spy)
                 scalar/start-transaction (spy/stub mock-transaction-throws-exception)]
     (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
                                nil nil)]
       (is (thrown? clojure.lang.ExceptionInfo
-                   (client/invoke! client {}
+                   (client/invoke! client {:storage (ref mock-storage)}
                                    (#'transfer/get-all {:client client}
                                                        nil))))
       (is (spy/called-n-times? cass/exponential-backoff scalar/RETRIES))
-      (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION)))))
+      (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION))
+      (is (spy/called-n-times? scalar/prepare-storage-service! scalar/RETRIES_FOR_RECONNECTION)))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]


### PR DESCRIPTION
After the change in [scalar-labs/scalardb#428](https://github.com/scalar-labs/scalardb/pull/428), we can't get the transactional meta columns from Transaction API. To get the transactional meta columns, we need to use Storage API. This PR fixes this issue. Please take a look!