### PR TITLE
check :cass-nodes

### DIFF
--- a/cassandra/src/cassandra/nemesis.clj
+++ b/cassandra/src/cassandra/nemesis.clj
@@ -63,7 +63,7 @@
                               (str "nemesis already disrupting " @nodes))
                             :no-target)
                    :stop (if-let [ns @nodes]
-                           (let [all-nodes (:nodes test)
+                           (let [all-nodes (or (:cass-nodes test) (:nodes test))
                                  decommissioned @(:decommissioned test)
                                  seed (-> test
                                           cass/seed-nodes

--- a/scalardl/src/scalardl/cassandra.clj
+++ b/scalardl/src/scalardl/cassandra.clj
@@ -23,6 +23,10 @@
                   (finally (alia/shutdown cluster)))]
     (and (not (empty? rows)) (= (-> rows first :tx_state) TX_COMMITTED))))
 
+(defn wait-cassandra-up
+  [node test]
+  (cassandra/wait-turn node test))
+
 (defn spinup-cassandra!
   [node test]
   (when (seq (System/getenv "LEAVE_CLUSTER_RUNNING"))

--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -152,7 +152,7 @@
         (do
           (install-server! node test)
           (info node "waiting for starting C* cluster")
-          (Thread/sleep (* 1000 60 (count (:cass-nodes test))))
+          (cassandra/wait-cassandra-up node test)
           (start-server! node test))
         (cassandra/spinup-cassandra! node test)))
 


### PR DESCRIPTION
Issue:
In the DL tests, the reordering to restart C* nodes didn't work when all C* nodes were down

Fix:
Use `:cass-nodes` if it is set