### PR TITLE
[DL] wait Cassandra nodes for the fixed time

### DIFF
--- a/scalardl/src/scalardl/cassandra.clj
+++ b/scalardl/src/scalardl/cassandra.clj
@@ -23,10 +23,6 @@
                   (finally (alia/shutdown cluster)))]
     (and (not (empty? rows)) (= (-> rows first :tx_state) TX_COMMITTED))))
 
-(defn wait-cassandra-up
-  [node test]
-  (cassandra/wait-turn node test))
-
 (defn spinup-cassandra!
   [node test]
   (when (seq (System/getenv "LEAVE_CLUSTER_RUNNING"))

--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -152,7 +152,7 @@
         (do
           (install-server! node test)
           (info node "waiting for starting C* cluster")
-          (cassandra/wait-cassandra-up node test)
+          (Thread/sleep (* 1000 60 (count (:cass-nodes test))))
           (start-server! node test))
         (cassandra/spinup-cassandra! node test)))
 


### PR DESCRIPTION
The DL server nodes failed to wait for Cassandra nodes.

Cause:
A DL server node didn't have `cqlsh` command and always failed to try to execute it because a test doesn't install Cassandra to the DL server node.

Fix:
A DL server node waits for Cassandra nodes for the fixed time without `cqlsh`