### PR TITLE
Update scalardl-java-client-sdk and protobuf version

### DIFF
--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -10,12 +10,12 @@
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.0.1" :exclusions [org.slf4j/slf4j-log4j12]]]}
+             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.3.1" :exclusions [org.slf4j/slf4j-log4j12]]]}
              :use-jars {:dependencies [[org.bouncycastle/bcpkix-jdk15on "1.59"]
                                        [org.bouncycastle/bcprov-jdk15on "1.59"]
                                        [com.google.inject/guice "4.2.0"]
                                        [com.moandjiezana.toml/toml4j "0.7.2"]
-                                       [com.google.protobuf/protobuf-java-util "3.13.0"]
+                                       [com.google.protobuf/protobuf-java-util "3.19.0"]
                                        [com.scalar-labs/scalar-admin "1.0.0"
                                         :exclusions [org.slf4j/slf4j-log4j12]]]
                         :resource-paths ["resources/scalardl-java-client-sdk.jar"

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -15,7 +15,7 @@
                                        [org.bouncycastle/bcprov-jdk15on "1.59"]
                                        [com.google.inject/guice "4.2.0"]
                                        [com.moandjiezana.toml/toml4j "0.7.2"]
-                                       [com.google.protobuf/protobuf-java-util "3.19.0"]
+                                       [com.google.protobuf/protobuf-java-util "3.19.2"]
                                        [com.scalar-labs/scalar-admin "1.0.0"
                                         :exclusions [org.slf4j/slf4j-log4j12]]]
                         :resource-paths ["resources/scalardl-java-client-sdk.jar"

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -10,7 +10,10 @@
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.3.1" :exclusions [org.slf4j/slf4j-log4j12]]]}
+             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.3.1"
+                                            :exclusions [org.slf4j/slf4j-log4j12
+                                                         com.oracle.database.jdbc/ojdbc8-production
+                                                         software.amazon.awssdk/*]]]}
              :use-jars {:dependencies [[org.bouncycastle/bcpkix-jdk15on "1.59"]
                                        [org.bouncycastle/bcprov-jdk15on "1.59"]
                                        [com.google.inject/guice "4.2.0"]

--- a/scalardl/test/scalardl/cas_test.clj
+++ b/scalardl/test/scalardl/cas_test.clj
@@ -27,6 +27,7 @@
       (ContractExecutionResult. (-> (Json/createObjectBuilder)
                                     (.add "value" 3)
                                     .build)
+                                nil
                                 nil))))
 
 (def mock-client-service-throws-unknown-status

--- a/scalardl/test/scalardl/transfer_test.clj
+++ b/scalardl/test/scalardl/transfer_test.clj
@@ -28,6 +28,7 @@
                                     (.add "balance" 1000)
                                     (.add "age" 111)
                                     .build)
+                                nil
                                 nil))))
 
 (def mock-failure-client-service


### PR DESCRIPTION
Update the `protobuf` version to 3.19.2 based on https://github.com/scalar-labs/scalar/pull/758 and update `scalardl-java-client-sdk` version to 3.3.1.