### PR TITLE
Should not create before prefixed columns for primary key columns

### DIFF
--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -33,7 +33,6 @@
                                :tx_state               :int
                                :tx_prepared_at         :bigint
                                :tx_committed_at        :bigint
-                               :before_account_id      :int
                                :before_balance         :int
                                :before_tx_id           :text
                                :before_tx_version      :int

--- a/scalardb/src/scalardb/transfer_2pc.clj
+++ b/scalardb/src/scalardb/transfer_2pc.clj
@@ -34,7 +34,6 @@
                                :tx_state               :int
                                :tx_prepared_at         :bigint
                                :tx_committed_at        :bigint
-                               :before_account_id      :int
                                :before_balance         :int
                                :before_tx_id           :text
                                :before_tx_version      :int


### PR DESCRIPTION
It looks like in the `transfer` test, before prefixed columns are created for primary key columns, which is unexpected behavior. This PR fixes this bug. Please take a look!