### PR TITLE
Updated dependencies to use snapshot versions

### DIFF
--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -11,7 +11,7 @@
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "4.0.0-SNAPSHOT'"
+             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "4.0.0-SNAPSHOT"
                                             :exclusions [org.slf4j/slf4j-log4j12
                                                          com.oracle.database.jdbc/ojdbc8-production
                                                          software.amazon.awssdk/*]]]}

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -8,7 +8,7 @@
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
-  :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots"}
+  :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
              :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "4.0.0-SNAPSHOT"

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -8,9 +8,10 @@
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
+  :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "3.3.1"
+             :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "4.0.0-SNAPSHOT'"
                                             :exclusions [org.slf4j/slf4j-log4j12
                                                          com.oracle.database.jdbc/ojdbc8-production
                                                          software.amazon.awssdk/*]]]}


### PR DESCRIPTION
Updated project.clj file to use snapshot versions for scalardl-java-client-sdk.