### PR TITLE
Fix the way to pass nonce (txid) since the current way is unofficial

### DIFF
--- a/scalardl/src/scalardl/transfer.clj
+++ b/scalardl/src/scalardl/transfer.clj
@@ -46,9 +46,8 @@
        (.add ASSET_ID id)
        (.add ASSET_BALANCE initial-balance)
        (.build)))
-  ([txid from to amount]
+  ([from to amount]
    (-> (Json/createObjectBuilder)
-       (.add NONCE txid)
        (.add ASSET_ID_FROM from)
        (.add ASSET_ID_TO to)
        (.add ASSET_AMOUNT amount)
@@ -112,9 +111,9 @@
     (case (:f op)
       :transfer (let [txid (str (java.util.UUID/randomUUID))
                       {:keys [from to amount]} (:value op)
-                      arg (create-argument txid from to amount)]
+                      arg (create-argument from to amount)]
                   (try
-                    (.executeContract @client-service "transfer" arg)
+                    (.executeContract @client-service txid "transfer" arg)
                     (assoc op :type :ok)
                     (catch ClientException e
                       (reset! client-service

--- a/scalardl/test/scalardl/transfer_test.clj
+++ b/scalardl/test/scalardl/transfer_test.clj
@@ -22,7 +22,7 @@
     (registerContract [_ _ _ _]
       (swap! contract-count inc)
       nil)
-    (executeContract [_ _]
+    (executeContract [& _]
       (swap! execute-count inc)
       (ContractExecutionResult. (-> (Json/createObjectBuilder)
                                     (.add "balance" 1000)
@@ -37,7 +37,7 @@
     (registerContract [_ _ _ _]
       (swap! contract-count inc)
       nil)
-    (executeContract [_ _]
+    (executeContract [& _]
       (swap! execute-count inc)
       (throw (ClientException. "the status is unknown"
                                (Exception.)


### PR DESCRIPTION
Basically the same fix as [this](https://github.com/scalar-labs/kelpie-test/pull/60).

This introduced the recent `Invalid analysis` error since a nonce given from a client is not used as a transaction ID in the server; thus, the nonce cannot be found in the coordinator table.