### PR TITLE
Wait for node readiness in DL tests

### DIFF
--- a/scalardl/src/scalardl/nemesis.clj
+++ b/scalardl/src/scalardl/nemesis.clj
@@ -18,7 +18,7 @@
    (fn stop  [test node]
      (when-not (util/server? node test)
        (meh (cass/guarded-start! node test))
-       (Thread/sleep (* 1000 60))
+       (meh (cass/wait-ready node 300 10 test))
        [:cassandra-restarted node]))))
 
 (defn crash


### PR DESCRIPTION
In Jepsen tests of Cassandra and Scalar DB, each node should wait for readiness.
However, the tests of DL didn’t because the nemesis is not the same as that of Cassandra and Scalar DB.