### PR TITLE
Create two two-phase commit transaction managers for 2PC tests

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -8,15 +8,14 @@
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
-             :use-released {:dependencies [[com.scalar-labs/scalardb "3.2.0"
+             :use-released {:dependencies [[com.scalar-labs/scalardb "3.7.0"
                                             ;; avoid the netty dependency issue
                                             :exclusions [software.amazon.awssdk/*
                                                          com.oracle.database.jdbc/ojdbc8-production
                                                          com.azure/azure-cosmos
                                                          io.grpc/grpc-core
                                                          com.scalar-labs/scalardb-rpc]]]}
-             :use-jars {:dependencies [[com.google.inject/guice "4.2.0"]
-                                       [com.google.guava/guava "31.1-jre"]]
+             :use-jars {:dependencies [[com.google.guava/guava "31.1-jre"]]
                         :resource-paths ["resources/scalardb.jar"]}
              :default [:base :system :user :provided :dev :use-released]}
   :jvm-opts ["-Djava.awt.headless=true"]

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -80,8 +80,8 @@
   (let [tms (:2pc test)]
     (locking tms
       (mapv #(.close %) @tms)
-        (reset! tms nil)
-        (info "The current 2pc service closed")))))
+      (reset! tms nil)
+      (info "The current 2pc service closed"))))
 
 (defn close-all!
   [test]

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -79,10 +79,7 @@
   [test]
   (let [tms (:2pc test)]
     (locking tms
-      (when @tms
-        (let [[tm1 tm2] @tms]
-          (.close tm1)
-          (.close tm2))
+      (mapv #(.close %) @tms)
         (reset! tms nil)
         (info "The current 2pc service closed")))))
 
@@ -169,14 +166,12 @@
 (defn start-2pc
   [test]
   ; use the first transaction manager to start a transaction
-  (let [[tm1 _] (deref (:2pc test))]
-    (some-> tm1 .start)))
+  (some-> test :2pc deref first .start))
 
 (defn join-2pc
   [test tx-id]
   ; use the second transaction manager to join a transaction
-  (let [[_ tm2] (deref (:2pc test))]
-    (some-> tm2 (.join tx-id))))
+  (some-> test :2pc deref second (.join tx-id)))
 
 (defmacro with-retry
   "If the result of the body is nil, it retries it"

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -101,7 +101,7 @@
 (deftest close-all-test
   (let [test {:storage (atom mock-storage)
               :transaction (atom mock-tx-manager)
-              :2pc (atom mock-2pc-manager)}]
+              :2pc (atom [mock-2pc-manager mock-2pc-manager])}]
     (scalar/close-all! test)
     (is (nil? @(:storage test)))
     (is (nil? @(:transaction test)))


### PR DESCRIPTION
After the change in https://github.com/scalar-labs/scalardb/pull/715, we need to create a two-phase commit transaction manager per sub-transaction. This PR modifies the 2PC tests for that.