### PR TITLE
Should return info type when UnknownTransactionStatusException

### DIFF
--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -142,7 +142,7 @@
                     (assoc op :type :ok)
                     (catch UnknownTransactionStatusException _
                       (swap! (:unknown-tx test) conj (.getId tx))
-                      (assoc op :type :fail :error {:unknown-tx-status (.getId tx)}))
+                      (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
                     (catch Exception e
                       (scalar/try-reconnection-for-transaction! test)
                       (assoc op :type :fail :error (.getMessage e))))

--- a/scalardb/src/scalardb/transfer_2pc.clj
+++ b/scalardb/src/scalardb/transfer_2pc.clj
@@ -157,7 +157,7 @@
                     (assoc op :type :ok)
                     (catch UnknownTransactionStatusException _
                       (swap! (:unknown-tx test) conj (.getId tx1))
-                      (assoc op :type :fail :error {:unknown-tx-status (.getId tx1)}))
+                      (assoc op :type :info :error {:unknown-tx-status (.getId tx1)}))
                     (catch Exception e
                       (scalar/try-reconnection-for-2pc! test)
                       (assoc op :type :fail :error (.getMessage e)))))

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -153,7 +153,7 @@
                     (assoc op :type :ok)
                     (catch UnknownTransactionStatusException _
                       (swap! (:unknown-tx test) conj (.getId tx))
-                      (assoc op :type :fail, :error {:unknown-tx-status (.getId tx)}))
+                      (assoc op :type :info, :error {:unknown-tx-status (.getId tx)}))
                     (catch Exception e
                       (scalar/try-reconnection-for-transaction! test)
                       (assoc op :type :fail, :error (.getMessage e))))

--- a/scalardb/src/scalardb/transfer_append_2pc.clj
+++ b/scalardb/src/scalardb/transfer_append_2pc.clj
@@ -167,7 +167,7 @@
                     (assoc op :type :ok)
                     (catch UnknownTransactionStatusException _
                       (swap! (:unknown-tx test) conj (.getId tx1))
-                      (assoc op :type :fail, :error {:unknown-tx-status (.getId tx1)}))
+                      (assoc op :type :info, :error {:unknown-tx-status (.getId tx1)}))
                     (catch Exception e
                       (scalar/try-reconnection-for-2pc! test)
                       (assoc op :type :fail, :error (.getMessage e)))))

--- a/scalardb/test/scalardb/transfer_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_2pc_test.clj
@@ -198,7 +198,7 @@
         (is (= 2 @prepare-count))
         (is (= 2 @validate-count))
         (is (= 0 @rollback-count))
-        (is (= :fail (:type result)))
+        (is (= :info (:type result)))
         (is (= "unknown-state-tx" (get-in result
                                           [:error :unknown-tx-status])))))))
 

--- a/scalardb/test/scalardb/transfer_append_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_append_2pc_test.clj
@@ -209,7 +209,7 @@
         (is (= 2 @prepare-count))
         (is (= 2 @validate-count))
         (is (= 0 @rollback-count))
-        (is (= :fail (:type result)))
+        (is (= :info (:type result)))
         (is (= "unknown-state-tx" (get-in result
                                           [:error :unknown-tx-status])))))))
 

--- a/scalardb/test/scalardb/transfer_append_test.clj
+++ b/scalardb/test/scalardb/transfer_append_test.clj
@@ -181,7 +181,7 @@
         (is (spy/not-called? scalar/try-reconnection-for-transaction!))
         (is (= 2 @scan-count))
         (is (= 2 @put-count))
-        (is (= :fail (:type result)))
+        (is (= :info (:type result)))
         (is (= "unknown-state-tx" (get-in result
                                           [:error :unknown-tx-status])))))))
 

--- a/scalardb/test/scalardb/transfer_test.clj
+++ b/scalardb/test/scalardb/transfer_test.clj
@@ -170,7 +170,7 @@
         (is (spy/not-called? scalar/try-reconnection-for-transaction!))
         (is (= 2 @get-count))
         (is (= 2 @put-count))
-        (is (= :fail (:type result)))
+        (is (= :info (:type result)))
         (is (= "unknown-state-tx" (get-in result
                                           [:error :unknown-tx-status])))))))
 


### PR DESCRIPTION
When `UnknownTransactionStatusException` is thrown, we are not sure the transaction is committed or not. In that case, we should return `:info` type. This PR fixes it. Please take a look!