### PR TITLE
Add commons text lib dependency

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -15,7 +15,8 @@
                                                          com.azure/azure-cosmos
                                                          io.grpc/grpc-core
                                                          com.scalar-labs/scalardb-rpc]]]}
-             :use-jars {:dependencies [[com.google.guava/guava "31.1-jre"]]
+             :use-jars {:dependencies [[com.google.guava/guava "31.1-jre"]
+                                       [org.apache.commons/commons-text "1.10.0"]]
                         :resource-paths ["resources/scalardb.jar"]}
              :default [:base :system :user :provided :dev :use-released]}
   :jvm-opts ["-Djava.awt.headless=true"]


### PR DESCRIPTION
After the change in https://github.com/scalar-labs/scalardb/pull/770 in ScalarDB, we need the commons text lib dependency in the ScalarDB Jepsen test. This PR adds it. Please take a look.