### PR TITLE
Add docker scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pom.xml
 */store/**
 */report/**
 */resources/ledger*
+docker/keys/

--- a/README.md
+++ b/README.md
@@ -1,37 +1,23 @@
 [![CircleCI](https://circleci.com/gh/scalar-labs/scalar-jepsen/tree/master.svg?style=svg)](https://circleci.com/gh/scalar-labs/scalar-jepsen/tree/master)
 
 # Run tests with Jepsen Docker
-1. Clone [Jepsen repository](https://github.com/jepsen-io/jepsen)
-    - Use 0.2.0 since 0.2.1+ uses newer debian version for DB nodes that does not have `openjdk-8-jre` package any more.
-2. Configure to mount `scalar-jepsen` directory by editing `${JEPSEN_ROOT}/docker/docker-compose.dev.yml` like the following
-
-```yaml
-   control:
-     volumes:
-       - ${JEPSEN_ROOT}:/jepsen # Mounts $JEPSEN_ROOT on host to /jepsen control container
-       - ${SCALAR_JEPSEN_ROOT}:/scalar-jepsen # $SCALAR_JEPSEN_ROOT is the path of this repository on host
-```
-
-3. Start docker with `--dev` option
-
+1. Move to the docker directory
 ```sh
-$ cd ${JEPSEN_ROOT}/docker
-$ ./up.sh --dev
+$ cd docker
 ```
-
-Note that you may need to update the `up.sh` script because there is an issue. See [this](https://github.com/jepsen-io/jepsen/issues/463) for more detail.
-
-4. Run tests in `jepsen-control`
-  - You can login `jepsen-control` by the following command
-  ```sh
-  $ docker exec -it jepsen-control bash
-  ```
-
+2. Run docker-compose
+```sh
+$ docker-compose up
+```
+3. Enter the control node
+```sh
+$ docker exec -it jepsen-control bash
+```
+4. Run a test
 ```
 # cd /scalar-jepsen/cassandra
 # lein run test --test lwt
 ```
-
   - Check README in each test for more detail
 
 # Run tests without Docker

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ $ cd docker
 ```
 2. Run docker-compose
 ```sh
-$ docker-compose up
+$ docker-compose up -d
 ```
 3. Enter the control node
 ```sh

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ $ docker exec -it jepsen-control bash
 4. Run a test
 ```
 # cd /scalar-jepsen/cassandra
-# lein run test --test lwt
+# lein run test --test lwt --ssh-private-key ~/.ssh/id_rsa
 ```
   - Check README in each test for more detail
+  - `--ssh-private-key` should be always set to specify the SSH key
 
 # Run tests without Docker
 1. Launch debian machines as a control machine and Cassandra nodes

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04
+ENV LEIN_ROOT=true
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y -q update && \
+    apt-get install -y \
+        openjdk-11-jdk \
+        libjna-java \
+        git \
+        gnuplot \
+        wget \
+        graphviz \
+        vim
+
+RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+    mv lein /usr/bin && \
+    chmod +x /usr/bin/lein && \
+    lein self-install
+
+ADD ./init.sh /init.sh
+RUN chmod +x /init.sh
+ENTRYPOINT ["sh", "/init.sh"]

--- a/docker/control/init.sh
+++ b/docker/control/init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 mkdir -m 700 ~/.ssh
-ssh-keygen -t rsa -b 4096 -N '' -f ~/.ssh/id_rsa
+ssh-keygen -t rsa -b 4096 -m PEM -N '' -f ~/.ssh/id_rsa
 cp ~/.ssh/id_rsa.pub /keys
 touch /keys/control_ready
 

--- a/docker/control/init.sh
+++ b/docker/control/init.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+mkdir -m 700 ~/.ssh
+ssh-keygen -t rsa -b 4096 -N '' -f ~/.ssh/id_rsa
+cp ~/.ssh/id_rsa.pub /keys
+touch /keys/control_ready
+
+echo > ~/.ssh/known_hosts
+for i in $(seq 1 5)
+do
+  while [ ! -f /keys/n${i}_ready ]
+  do
+    sleep 1
+  done
+  ssh-keyscan -t rsa n${i} >> ~/.ssh/known_hosts
+done
+
+rm /keys/*
+
+# keep running
+tail -f /dev/null

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '3.9'
+
+x-node:
+  &default-node
+  build: ./node
+  privileged: true
+  networks:
+    - jepsen
+  volumes:
+    - ./keys:/keys
+
+services:
+  control:
+    container_name: jepsen-control
+    hostname: control
+    build: ./control
+    privileged: true
+    ports:
+      - 8080
+    networks:
+      - jepsen
+    volumes:
+      - ./keys:/keys
+      - ../:/scalar-jepsen
+      - /scalar-jepsen/docker
+  n1:
+    << : *default-node
+    container_name: jepsen-n1
+    hostname: n1
+  n2:
+    << : *default-node
+    container_name: jepsen-n2
+    hostname: n2
+  n3:
+    << : *default-node
+    container_name: jepsen-n3
+    hostname: n3
+  n4:
+    << : *default-node
+    container_name: jepsen-n4
+    hostname: n4
+  n5:
+    << : *default-node
+    container_name: jepsen-n5
+    hostname: n5
+
+networks:
+  jepsen:

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get -y -q update && \
     openssh-server \
     psmisc \
     python \
-    ntpdate
+    ntpdate \
+    iptables
 
 ADD ./init.sh /init.sh
 RUN chmod +x /init.sh

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:20.04
+
+RUN apt-get -y -q update && \
+    apt-get install -y \
+    sudo \
+    openssh-server \
+    psmisc \
+    python \
+    ntpdate
+
+ADD ./init.sh /init.sh
+RUN chmod +x /init.sh
+ENTRYPOINT ["sh", "/init.sh"]

--- a/docker/node/init.sh
+++ b/docker/node/init.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+mkdir -p /var/run/sshd
+sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config
+sed -i "s/PermitRootLogin without-password/PermitRootLogin yes/g" /etc/ssh/sshd_config
+
+# wait for updating the ssh key
+while [ ! -f /keys/control_ready ]
+do
+  sleep 1
+done
+
+mkdir -p ~/.ssh
+cat /keys/id_rsa.pub >> ~/.ssh/authorized_keys
+hostname=$(hostname)
+touch /keys/${hostname}_ready
+
+exec /usr/sbin/sshd -D


### PR DESCRIPTION
Add docker files to set up a local test environment easily

Jepsen also has scripts for docker env.
However, it doesn't support arm64, and some configurations aren't required for `scalar-jepsen`.

That's why I made docker scripts for `scalar-jepsen`.