### PR TITLE
Upgrade Jepsen to 0.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/scalar-jepsen
 
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.1
+      - image: circleci/clojure:openjdk-11-lein-2.9.8
 
     environment:
       JVM_OPTS: -Xmx3200m

--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/java.jmx "0.3.1"]
-                 [jepsen "0.3.0" :exclusions [net.java.dev.jna/jna
+                 [jepsen "0.3.1" :exclusions [net.java.dev.jna/jna
                                               net.java.dev.jna/jna-platform]]
                  [net.java.dev.jna/jna "5.11.0"]
                  [net.java.dev.jna/jna-platform "5.11.0"]

--- a/cassandra/project.clj
+++ b/cassandra/project.clj
@@ -3,9 +3,12 @@
   :url "http://github.com/scalar-labs/jepsen"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/java.jmx "0.3.1"]
-                 [jepsen "0.2.1"]
+                 [jepsen "0.3.0" :exclusions [net.java.dev.jna/jna
+                                              net.java.dev.jna/jna-platform]]
+                 [net.java.dev.jna/jna "5.11.0"]
+                 [net.java.dev.jna/jna-platform "5.11.0"]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -2,7 +2,7 @@
   :description "Jepsen testing for Scalar DB"
   :url "https://github.com/scalar-labs/scalar-jepsen"
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.3.0" :exclusions [net.java.dev.jna/jna
+                 [jepsen "0.3.1" :exclusions [net.java.dev.jna/jna
                                               net.java.dev.jna/jna-platform]]
                  [net.java.dev.jna/jna "5.11.0"]
                  [net.java.dev.jna/jna-platform "5.11.0"]

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -1,8 +1,12 @@
 (defproject scalardb "0.1.0-SNAPSHOT"
   :description "Jepsen testing for Scalar DB"
   :url "https://github.com/scalar-labs/scalar-jepsen"
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.2.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [jepsen "0.3.0" :exclusions [net.java.dev.jna/jna
+                                              net.java.dev.jna/jna-platform]]
+                 [net.java.dev.jna/jna "5.11.0"]
+                 [net.java.dev.jna/jna-platform "5.11.0"]
+                 [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -3,8 +3,12 @@
   :url "https://github.com/scalar-labs/scalar-jepsen"
   :license {:name ""
             :url ""}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [jepsen "0.2.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [jepsen "0.3.0" :exclusions [net.java.dev.jna/jna
+                                              net.java.dev.jna/jna-platform]]
+                 [net.java.dev.jna/jna "5.11.0"]
+                 [net.java.dev.jna/jna-platform "5.11.0"]
+                 [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
@@ -13,8 +17,7 @@
                    :plugins [[lein-cloverage "1.1.2"]]}
              :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "4.0.0-SNAPSHOT"
                                             :exclusions [org.slf4j/slf4j-log4j12
-                                                         com.oracle.database.jdbc/ojdbc8
-                                                         software.amazon.awssdk/*]]]}
+                                                         com.scalar-labs/scalardb]]]}
              :use-jars {:dependencies [[org.bouncycastle/bcpkix-jdk15on "1.59"]
                                        [org.bouncycastle/bcprov-jdk15on "1.59"]
                                        [com.google.inject/guice "4.2.0"]

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -4,7 +4,7 @@
   :license {:name ""
             :url ""}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.3.0" :exclusions [net.java.dev.jna/jna
+                 [jepsen "0.3.1" :exclusions [net.java.dev.jna/jna
                                               net.java.dev.jna/jna-platform]]
                  [net.java.dev.jna/jna "5.11.0"]
                  [net.java.dev.jna/jna-platform "5.11.0"]

--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -114,7 +114,7 @@
   []
   (retry-when-exception (fn [package]
                           (c/su (debian/install package)))
-                        [[:openjdk-8-jre]]
+                        [[:openjdk-11-jre]]
                         debian/update!))
 
 (defn- install-server!


### PR DESCRIPTION
There are many changes, but, it should be compatible.
Steady tests worked well.
After this upgrade, I'll refine the nemesis injections.

Ref. https://github.com/jepsen-io/jepsen/releases/tag/v0.3.0

Also, It updated dependencies in `project.clj`.