### PR TITLE
Add null transaction metadata option

### DIFF
--- a/cassandra/src/cassandra/core.clj
+++ b/cassandra/src/cassandra/core.clj
@@ -287,6 +287,13 @@
                                       (with {:compaction
                                              {:class compaction-strategy}}))))
 
+(defn insert-record
+  [session {:keys [keyspace table columns]}]
+  (alia/execute session (use-keyspace (keyword keyspace)))
+  (alia/execute session (insert (keyword table)
+                                (values columns)
+                                (if-exists false))))
+
 (defn close-cassandra
   [cluster session]
   (some-> session alia/shutdown (.get 10 TimeUnit/SECONDS))

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -20,6 +20,7 @@
 (def ^:private ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
 (def ^:const INITIAL_TABLE_ID 1)
 (def ^:const DEFAULT_TABLE_COUNT 3)
+(def ^:const DEFAULT_KEY_COUNT 10)
 
 (def ^:private ^:const COORDINATOR "coordinator")
 (def ^:private ^:const STATE_TABLE "state")
@@ -264,3 +265,13 @@
     {:stats (independent-stats-checker)
      :exceptions (checker/unhandled-exceptions)
      :workload (independent-workload-checker workload-checker)})))
+
+(defn setup-records-without-tx-metadata
+  [test keyspace table]
+  (let [cluster (alia/cluster {:contact-points (:nodes test)})
+        session (alia/connect cluster)]
+    (doseq [i (range DEFAULT_KEY_COUNT)]
+      (retry-when-exception
+        (fn [n] (c/insert-record session {:keyspace keyspace
+                                          :table table
+                                          :columns [[:id n] [:val 999]]}))[i]))))

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -6,7 +6,8 @@
             [jepsen.independent :as independent]
             [jepsen.tests.cycle.append :as append]
             [scalardb.core :as scalar :refer [INITIAL_TABLE_ID
-                                              DEFAULT_TABLE_COUNT]])
+                                              DEFAULT_TABLE_COUNT
+                                              DEFAULT_KEY_COUNT]])
   (:import (com.scalar.db.api Get
                               Put)
            (com.scalar.db.io IntValue
@@ -130,7 +131,7 @@
 
 (defn- append-test
   [opts]
-  (append/test {:key-count 10
+  (append/test {:key-count DEFAULT_KEY_COUNT
                 :min-txn-length 1
                 :max-txn-length 10
                 :max-writes-per-key 10

--- a/scalardb/src/scalardb/elle_append_2pc.clj
+++ b/scalardb/src/scalardb/elle_append_2pc.clj
@@ -6,7 +6,8 @@
             [jepsen.independent :as independent]
             [jepsen.tests.cycle.append :as append]
             [scalardb.core :as scalar :refer [INITIAL_TABLE_ID
-                                              DEFAULT_TABLE_COUNT]])
+                                              DEFAULT_TABLE_COUNT
+                                              DEFAULT_KEY_COUNT]])
   (:import (com.scalar.db.api Get
                               Put)
            (com.scalar.db.io IntValue
@@ -138,7 +139,7 @@
 
 (defn- append-test
   [opts]
-  (append/test {:key-count 10
+  (append/test {:key-count DEFAULT_KEY_COUNT
                 :min-txn-length 1
                 :max-txn-length 10
                 :max-writes-per-key 10

--- a/scalardb/src/scalardb/elle_write_read_2pc.clj
+++ b/scalardb/src/scalardb/elle_write_read_2pc.clj
@@ -5,7 +5,8 @@
             [jepsen.independent :as independent]
             [jepsen.tests.cycle.wr :as wr]
             [scalardb.core :as scalar :refer [INITIAL_TABLE_ID
-                                              DEFAULT_TABLE_COUNT]])
+                                              DEFAULT_TABLE_COUNT
+                                              DEFAULT_KEY_COUNT]])
   (:import (com.scalar.db.api Get
                               Put)
            (com.scalar.db.io IntValue
@@ -74,12 +75,12 @@
         (when (compare-and-set! (:table-id test) current-id next-id)
           (info (str "Creating new tables for " next-id))
           (doseq [i (range DEFAULT_TABLE_COUNT)]
-            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                    :table (str TABLE
-                                                                next-id
-                                                                \_
-                                                                i)
-                                                    :schema SCHEMA}])))))))
+            (let [table (str TABLE next-id \_ i)]
+              (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                      :table table
+                                                      :schema SCHEMA}])
+              (if (:use-null-tx-metadata test)
+                (scalar/setup-records-without-tx-metadata test KEYSPACE table)))))))))
 
 (defrecord WriteReadClient [initialized?]
   client/Client
@@ -91,9 +92,12 @@
       (when (compare-and-set! initialized? false true)
         (doseq [id (range (inc INITIAL_TABLE_ID))
                 i (range DEFAULT_TABLE_COUNT)]
-          (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                  :table (str TABLE id \_ i)
-                                                  :schema SCHEMA}]))
+          (let [table (str TABLE id \_ i)]
+            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
+                                                    :table table
+                                                    :schema SCHEMA}])
+            (if (:use-null-tx-metadata test)
+              (scalar/setup-records-without-tx-metadata test KEYSPACE table))))
         (scalar/prepare-2pc-service! test))))
 
   (invoke! [_ test op]
@@ -128,7 +132,7 @@
 
 (defn- write-read-gen
   []
-  (wr/gen {:key-count 10
+  (wr/gen {:key-count DEFAULT_KEY_COUNT
            :min-txn-length 1
            :max-txn-length 10
            :max-writes-per-key 10}))

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -55,7 +55,10 @@
 
    (cli/repeated-opt nil "--consistency-model CONSISTENCY_MODEL"
                      "consistency model to be checked"
-                     ["snapshot-isolation"])])
+                     ["snapshot-isolation"])
+
+   [nil "--use-null-tx-metadata" "Use null transaction metadata to test with existing tables."
+    :default false]])
 
 (defn test-cmd
   []


### PR DESCRIPTION
This PR adds an option to prepare records with null transaction metadata before starting tests. This option is for ScalarDB with existing database tables, where the records only have user data in their columns (i.e., the transaction metadata is null) after migrating to ScalarDB.

Note that the option can only work with ScalarDB 4.0.0-SNAPSHOT since 3.9.0 or earlier cannot handle null metadata.