### PR TITLE
Scalardb/cleanup cassandra deps

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -9,7 +9,7 @@
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cheshire "5.12.0"]
-                 [com.scalar-labs/scalardb-schema-loader "3.10.1"]]
+                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -9,7 +9,9 @@
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cc.qbits/alia "4.3.6"]
-                 [cc.qbits/hayt "4.1.0"]]
+                 [cc.qbits/hayt "4.1.0"]
+                 [cheshire "5.12.0"]
+                 [com.scalar-labs/scalardb-schema-loader "3.10.1"]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -8,8 +8,6 @@
                  [net.java.dev.jna/jna-platform "5.11.0"]
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
-                 [cc.qbits/alia "4.3.6"]
-                 [cc.qbits/hayt "4.1.0"]
                  [cheshire "5.12.0"]
                  [com.scalar-labs/scalardb-schema-loader "3.10.1"]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -19,7 +19,7 @@
 (def ^:const KEYSPACE "jepsen")
 (def ^:const VERSION "tx_version")
 
-(defn- exponential-backoff
+(defn exponential-backoff
   [r]
   (Thread/sleep (reduce * 1000 (repeat r 2))))
 

--- a/scalardb/src/scalardb/db_extend.clj
+++ b/scalardb/src/scalardb/db_extend.clj
@@ -1,0 +1,62 @@
+(ns scalardb.db-extend
+  (:require [cassandra.core :as cassandra]
+            [clojure.string :as string]
+            [jepsen.db :as db])
+  (:import (com.scalar.db.storage.cassandra CassandraAdmin
+                                            CassandraAdmin$ReplicationStrategy
+                                            CassandraAdmin$CompactionStrategy)
+           (java.util Properties)))
+
+(def ^:private ISOLATION_LEVELS {:snapshot "SNAPSHOT"
+                                 :serializable "SERIALIZABLE"})
+
+(def ^:private SERIALIZABLE_STRATEGIES {:extra-read "EXTRA_READ"
+                                        :extra-write "EXTRA_WRITE"})
+
+(defprotocol DbExtension
+  (live-nodes [this test])
+  (create-table-opts [this test])
+  (create-properties [this test]))
+
+(def ^:private cassandra-functions
+    {:live-nodes (fn [_ test] (cassandra/live-nodes test))
+     :create-table-opts
+     (fn [_ test]
+       {(keyword CassandraAdmin/REPLICATION_STRATEGY)
+        (str CassandraAdmin$ReplicationStrategy/SIMPLE_STRATEGY)
+        (keyword CassandraAdmin/COMPACTION_STRATEGY)
+        (str CassandraAdmin$CompactionStrategy/LCS)
+        (keyword CassandraAdmin/REPLICATION_FACTOR) (:rf test)})
+     :create-properties
+     (fn [_ test]
+       (let [nodes (cassandra/live-nodes test)]
+         (when (nil? nodes)
+           (throw (ex-info "No living node" {:test test})))
+         (doto (Properties.)
+           (.setProperty "scalar.db.contact_points" (string/join "," nodes))
+           (.setProperty "scalar.db.username" "cassandra")
+           (.setProperty "scalar.db.password" "cassandra")
+           (.setProperty "scalar.db.isolation_level"
+                         ((:isolation-level test) ISOLATION_LEVELS))
+           (.setProperty "scalar.db.consensus_commit.serializable_strategy"
+                         ((:serializable-strategy test) SERIALIZABLE_STRATEGIES)))))})
+
+(def ext-db-functions
+  {:cassandra cassandra-functions})
+
+(defn extend-db
+  [db db-type]
+  (let [ext-fns (db-type ext-db-functions)]
+  (reify
+    db/DB
+    (db/setup! [_ test node] (db/setup! db test node))
+    (db/teardown! [_ test node] (db/teardown! db test node))
+    db/Primary
+    (primaries [_ test] (db/primaries db test))
+    (setup-primary! [_ test node] (db/setup-primary! db test node))
+    db/LogFiles
+    (log-files [_ test node] (db/log-files db test node))
+    DbExtension
+    (live-nodes [_ test] ((:live-nodes ext-fns) db test))
+    (create-table-opts [_ test] ((:create-table-opts ext-fns) db test))
+    (create-properties [_ test] ((:create-properties ext-fns) db test)))))

--- a/scalardb/src/scalardb/db_extend.clj
+++ b/scalardb/src/scalardb/db_extend.clj
@@ -15,48 +15,52 @@
 
 (defprotocol DbExtension
   (live-nodes [this test])
+  (wait-for-recovery [this test])
   (create-table-opts [this test])
   (create-properties [this test]))
 
-(def ^:private cassandra-functions
-    {:live-nodes (fn [_ test] (cassandra/live-nodes test))
-     :create-table-opts
-     (fn [_ test]
-       {(keyword CassandraAdmin/REPLICATION_STRATEGY)
-        (str CassandraAdmin$ReplicationStrategy/SIMPLE_STRATEGY)
-        (keyword CassandraAdmin/COMPACTION_STRATEGY)
-        (str CassandraAdmin$CompactionStrategy/LCS)
-        (keyword CassandraAdmin/REPLICATION_FACTOR) (:rf test)})
-     :create-properties
-     (fn [_ test]
-       (let [nodes (cassandra/live-nodes test)]
-         (when (nil? nodes)
-           (throw (ex-info "No living node" {:test test})))
-         (doto (Properties.)
-           (.setProperty "scalar.db.contact_points" (string/join "," nodes))
-           (.setProperty "scalar.db.username" "cassandra")
-           (.setProperty "scalar.db.password" "cassandra")
-           (.setProperty "scalar.db.isolation_level"
-                         ((:isolation-level test) ISOLATION_LEVELS))
-           (.setProperty "scalar.db.consensus_commit.serializable_strategy"
-                         ((:serializable-strategy test) SERIALIZABLE_STRATEGIES)))))})
+(defrecord ExtCassandra []
+  DbExtension
+  (live-nodes [_ test] (cassandra/live-nodes test))
+  (wait-for-recovery [_ test] (cassandra/wait-rf-nodes test))
+  (create-table-opts
+    [_ test]
+    {(keyword CassandraAdmin/REPLICATION_STRATEGY)
+     (str CassandraAdmin$ReplicationStrategy/SIMPLE_STRATEGY)
+     (keyword CassandraAdmin/COMPACTION_STRATEGY)
+     (str CassandraAdmin$CompactionStrategy/LCS)
+     (keyword CassandraAdmin/REPLICATION_FACTOR) (:rf test)})
+  (create-properties
+    [_ test]
+    (let [nodes (cassandra/live-nodes test)]
+      (when (nil? nodes)
+        (throw (ex-info "No living node" {:test test})))
+      (doto (Properties.)
+        (.setProperty "scalar.db.contact_points" (string/join "," nodes))
+        (.setProperty "scalar.db.username" "cassandra")
+        (.setProperty "scalar.db.password" "cassandra")
+        (.setProperty "scalar.db.consensus_commit.isolation_level"
+                      ((:isolation-level test) ISOLATION_LEVELS))
+        (.setProperty "scalar.db.consensus_commit.serializable_strategy"
+                      ((:serializable-strategy test) SERIALIZABLE_STRATEGIES))))))
 
-(def ext-db-functions
-  {:cassandra cassandra-functions})
+(def ^:private ext-dbs
+  {:cassandra (->ExtCassandra)})
 
 (defn extend-db
   [db db-type]
-  (let [ext-fns (db-type ext-db-functions)]
-  (reify
-    db/DB
-    (db/setup! [_ test node] (db/setup! db test node))
-    (db/teardown! [_ test node] (db/teardown! db test node))
-    db/Primary
-    (primaries [_ test] (db/primaries db test))
-    (setup-primary! [_ test node] (db/setup-primary! db test node))
-    db/LogFiles
-    (log-files [_ test node] (db/log-files db test node))
-    DbExtension
-    (live-nodes [_ test] ((:live-nodes ext-fns) db test))
-    (create-table-opts [_ test] ((:create-table-opts ext-fns) db test))
-    (create-properties [_ test] ((:create-properties ext-fns) db test)))))
+  (let [ext-db (db-type ext-dbs)]
+    (reify
+      db/DB
+      (setup! [_ test node] (db/setup! db test node))
+      (teardown! [_ test node] (db/teardown! db test node))
+      db/Primary
+      (primaries [_ test] (db/primaries db test))
+      (setup-primary! [_ test node] (db/setup-primary! db test node))
+      db/LogFiles
+      (log-files [_ test node] (db/log-files db test node))
+      DbExtension
+      (live-nodes [_ test] (live-nodes ext-db test))
+      (wait-for-recovery [_ test] (wait-for-recovery ext-db test))
+      (create-table-opts [_ test] (create-table-opts ext-db test))
+      (create-properties [_ test] (create-properties ext-db test)))))

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -17,22 +17,12 @@
             UnknownTransactionStatusException)))
 
 (def ^:const TABLE "txn")
-(def ^:const SCHEMA {:id                     :int
-                     :val                    :text
-                     :tx_id                  :text
-                     :tx_version             :int
-                     :tx_state               :int
-                     :tx_prepared_at         :bigint
-                     :tx_committed_at        :bigint
-                     :before_val             :text
-                     :before_tx_id           :text
-                     :before_tx_version      :int
-                     :before_tx_state        :int
-                     :before_tx_prepared_at  :bigint
-                     :before_tx_committed_at :bigint
-                     :primary-key [:id]})
 (def ^:private ^:const ID "id")
 (def ^:private ^:const VALUE "val")
+(def ^:const SCHEMA {:transaction true
+                     :partition-key [ID]
+                     :clustering-key []
+                     :columns {(keyword ID) "INT" (keyword VALUE) "INT"}})
 
 (defn prepare-get
   [table id]
@@ -80,9 +70,8 @@
   [test]
   (doseq [id (range (inc INITIAL_TABLE_ID))
           i (range DEFAULT_TABLE_COUNT)]
-    (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                            :table (str TABLE id \_ i)
-                                            :schema SCHEMA}])))
+    (scalar/setup-transaction-tables
+     test [{(keyword (str KEYSPACE \. TABLE id \_ i)) SCHEMA}])))
 
 (defn add-tables
   [test next-id]
@@ -92,12 +81,9 @@
         (when (compare-and-set! (:table-id test) current-id next-id)
           (info (str "Creating new tables for " next-id))
           (doseq [i (range DEFAULT_TABLE_COUNT)]
-            (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                                    :table (str TABLE
-                                                                next-id
-                                                                \_
-                                                                i)
-                                                    :schema SCHEMA}])))))))
+            (scalar/setup-transaction-tables
+             test
+             [{(keyword (str KEYSPACE \. TABLE next-id \_ i)) SCHEMA}])))))))
 
 (defrecord AppendClient [initialized?]
   client/Client

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -65,7 +65,7 @@
 
 (def test-opt-spec
   [(cli/repeated-opt nil "--db NAME" "DB(s) on which the test is run"
-                     ["cassandra"] db-keys)
+                     [:cassandra] db-keys)
 
    (cli/repeated-opt nil "--workload NAME" "Test(s) to run" [] workload-keys)
 

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -1,8 +1,8 @@
 (ns scalardb.runner
   (:gen-class)
-  (:require [cassandra.runner :as car]
-            [cassandra.core :as cassandra]
+  (:require [cassandra.core :as cassandra]
             [cassandra.nemesis :as cn]
+            [cassandra.runner :as car]
             [clojure.string :as string]
             [jepsen
              [core :as jepsen]

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -118,7 +118,6 @@
             :pure-generators true
             :generator (gen/phases
                         (->> (:generator workload)
-                             gen/mix
                              (gen/nemesis
                               (gen/phases
                                (gen/sleep 5)

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -104,13 +104,14 @@
 
 (defn scalardb-test
   [base-opts db-key workload-key faults admin]
-  (let [workload ((workload-key workloads) base-opts)
-        [db nemesis] (gen-db db-key faults admin)
-        consistency-model (->> base-opts :consistency-model (mapv keyword))]
+  (let [[db nemesis] (gen-db db-key faults admin)
+        consistency-model (->> base-opts :consistency-model (mapv keyword))
+        workload-opts (merge base-opts
+                             scalardb-opts
+                             {:consistency-model consistency-model})
+        workload ((workload-key workloads) workload-opts)]
     (merge tests/noop-test
-           base-opts
-           scalardb-opts
-           {:consistency-model consistency-model}
+           workload-opts
            {:name (test-name workload-key faults admin)
             :client (:client workload)
             :db db

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -1,9 +1,14 @@
 (ns scalardb.runner
   (:gen-class)
   (:require [cassandra.runner :as car]
+            [cassandra.core :as cassandra]
+            [cassandra.nemesis :as cn]
+            [clojure.string :as string]
             [jepsen
              [core :as jepsen]
-             [cli :as cli]]
+             [cli :as cli]
+             [generator :as gen]
+             [tests :as tests]]
             [scalardb
              [core :refer [INITIAL_TABLE_ID]]
              [transfer]
@@ -15,6 +20,26 @@
              [elle-append-2pc]
              [elle-write-read-2pc]
              [db-extend :refer [extend-db]]]))
+
+(def db-keys
+  "The map of test DBs."
+  {"cassandra" :cassandra})
+
+(defn- gen-db
+  [db-key faults admin]
+  (case db-key
+    :cassandra (let [db (extend-db (cassandra/db) :cassandra)]
+                 [db
+                  (cn/nemesis-package
+                   {:db db
+                    :faults faults
+                    :admin admin
+                    :partition {:targets [:one
+                                          :primaries
+                                          :majority
+                                          :majorities-ring
+                                          :minority-third]}})])
+    (throw (ex-info "Unsupported DB" {:db db-key}))))
 
 (def workload-keys
   "A map of test workload keys."
@@ -39,7 +64,10 @@
    :elle-write-read-2pc scalardb.elle-write-read-2pc/workload})
 
 (def test-opt-spec
-  [(cli/repeated-opt nil "--workload NAME" "Test(s) to run" [] workload-keys)
+  [(cli/repeated-opt nil "--db NAME" "DB(s) on which the test is run"
+                     ["cassandra"] db-keys)
+
+   (cli/repeated-opt nil "--workload NAME" "Test(s) to run" [] workload-keys)
 
    [nil "--isolation-level ISOLATION_LEVEL" "isolation level"
     :default :snapshot
@@ -58,21 +86,47 @@
                      "consistency model to be checked"
                      ["snapshot-isolation"])])
 
-(defn- init-scalardb-test
-  [opts workload nemesis admin]
-  (-> opts
-      (assoc :target "scalardb"
-             :workload workload
-             :nemesis nemesis
-             :admin admin
-             :storage (atom nil)
-             :transaction (atom nil)
-             :2pc (atom nil)
-             :table-id (atom INITIAL_TABLE_ID)
-             :unknown-tx (atom #{})
-             :failures (atom 0))
-      (update :consistency-model
-              (fn [ms] (mapv keyword ms)))))
+(defn- test-name
+  [workload-key faults admin]
+  (-> ["scalardb" (name workload-key)]
+      (into (map name faults))
+      (into (map name admin))
+      (->> (remove nil?) (string/join "-"))))
+
+(def ^:private scalardb-opts
+  {:storage (atom nil)
+   :transaction (atom nil)
+   :2pc (atom nil)
+   :table-id (atom INITIAL_TABLE_ID)
+   :unknown-tx (atom #{})
+   :failures (atom 0)
+   :decommissioned (atom #{})})
+
+(defn scalardb-test
+  [base-opts db-key workload-key faults admin]
+  (let [workload ((workload-key workloads) base-opts)
+        [db nemesis] (gen-db db-key faults admin)
+        consistency-model (->> base-opts :consistency-model (mapv keyword))]
+    (merge tests/noop-test
+           base-opts
+           scalardb-opts
+           {:consistency-model consistency-model}
+           {:name (test-name workload-key faults admin)
+            :client (:client workload)
+            :db db
+            :pure-generators true
+            :generator (gen/phases
+                        (->> (:generator workload)
+                             gen/mix
+                             (gen/nemesis
+                              (gen/phases
+                               (gen/sleep 5)
+                               (:generator nemesis)))
+                             (gen/time-limit (:time-limit base-opts)))
+                        (gen/nemesis (:final-generator nemesis))
+                        (gen/clients (:final-generator workload)))
+            :nemesis (:nemesis nemesis)
+            :checker (:checker workload)})))
 
 (defn test-cmd
   []
@@ -82,22 +136,19 @@
            :opt-fn (fn [parsed] (-> parsed cli/test-opt-fn))
            :usage (cli/test-usage)
            :run (fn [{:keys [options]}]
-                  (with-redefs [car/workloads workloads]
-                    (doseq [_ (range (:test-count options))
-                            workload (:workload options)
-                            nemesis (:nemesis options)
-                            admin (:admin options)]
-                      (let [opts (init-scalardb-test options
-                                                     workload
-                                                     nemesis
-                                                     admin)
-                            updated-opts (-> opts
-                                             car/cassandra-test
-                                             (update :db
-                                                     #(extend-db % :cassandra)))
-                            test (jepsen/run! updated-opts)]
-                        (when-not (:valid? (:results test))
-                          (System/exit 1))))))}})
+                  (doseq [_ (range (:test-count options))
+                          db-key (:db options)
+                          workload-key (:workload options)
+                          faults (:nemesis options)
+                          admin (:admin options)]
+                    (let [test (-> options
+                                   (scalardb-test db-key
+                                                  workload-key
+                                                  faults
+                                                  admin)
+                                   jepsen/run!)]
+                      (when-not (:valid? (:results test))
+                        (System/exit 1)))))}})
 
 (defn -main
   [& args]

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -25,26 +25,16 @@
 (def ^:const NUM_ACCOUNTS 10)
 (def ^:private ^:const TOTAL_BALANCE (* NUM_ACCOUNTS INITIAL_BALANCE))
 
-(def ^:const SCHEMA {:account_id             :int
-                     :balance                :int
-                     :tx_id                  :text
-                     :tx_version             :int
-                     :tx_state               :int
-                     :tx_prepared_at         :bigint
-                     :tx_committed_at        :bigint
-                     :before_balance         :int
-                     :before_tx_id           :text
-                     :before_tx_version      :int
-                     :before_tx_state        :int
-                     :before_tx_prepared_at  :bigint
-                     :before_tx_committed_at :bigint
-                     :primary-key            [:account_id]})
+(def ^:const SCHEMA {(keyword (str KEYSPACE \. TABLE))
+                     {:transaction true
+                      :partition-key [ACCOUNT_ID]
+                      :clustering-key []
+                      :columns {(keyword ACCOUNT_ID) "INT"
+                                (keyword BALANCE) "INT"}}})
 
 (defn setup-tables
   [test]
-  (scalar/setup-transaction-tables test [{:keyspace KEYSPACE
-                                          :table TABLE
-                                          :schema SCHEMA}]))
+  (scalar/setup-transaction-tables test [SCHEMA]))
 
 (defn prepare-get
   [id]

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -1,12 +1,12 @@
 (ns scalardb.transfer
-  (:require [cassandra.core :as cassandra]
-            [clojure.core.reducers :as r]
+  (:require [clojure.core.reducers :as r]
             [jepsen
              [client :as client]
              [checker :as checker]
              [generator :as gen]]
             [knossos.op :as op]
-            [scalardb.core :as scalar :refer [KEYSPACE]])
+            [scalardb.core :as scalar :refer [KEYSPACE]]
+            [scalardb.db-extend :refer [wait-for-recovery]])
   (:import (com.scalar.db.api Consistency
                               Get
                               Put
@@ -143,7 +143,7 @@
                     (scalar/try-reconnection-for-transaction! test)
                     (assoc op :type :fail :error "Skipped due to no connection")))
       :get-all (do
-                 (cassandra/wait-rf-nodes test)
+                 (wait-for-recovery (:db test) test)
                  (if-let [results (read-all-with-retry test (:num op))]
                    (assoc op :type :ok :value {:balance (get-balances results)
                                                :version (get-versions results)})

--- a/scalardb/src/scalardb/transfer_2pc.clj
+++ b/scalardb/src/scalardb/transfer_2pc.clj
@@ -1,10 +1,10 @@
 (ns scalardb.transfer-2pc
-  (:require [cassandra.core :as cassandra]
-            [jepsen
+  (:require [jepsen
              [client :as client]
              [generator :as gen]]
             [scalardb.core :as scalar]
-            [scalardb.transfer :as transfer])
+            [scalardb.transfer :as transfer]
+            [scalardb.db-extend :refer [wait-for-recovery]])
   (:import (com.scalar.db.exception.transaction UnknownTransactionStatusException)))
 
 (defn- tx-transfer
@@ -54,7 +54,7 @@
                       (scalar/try-reconnection-for-2pc! test)
                       (assoc op :type :fail :error (.getMessage e)))))
       :get-all (do
-                 (cassandra/wait-rf-nodes test)
+                 (wait-for-recovery (:db test) test)
                  (if-let [results (transfer/read-all-with-retry test (:num op))]
                    (assoc op :type :ok :value {:balance
                                                (transfer/get-balances results)

--- a/scalardb/src/scalardb/transfer_append_2pc.clj
+++ b/scalardb/src/scalardb/transfer_append_2pc.clj
@@ -1,10 +1,10 @@
 (ns scalardb.transfer-append-2pc
-  (:require [cassandra.core :as cassandra]
-            [clojure.tools.logging :refer [info]]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen
              [client :as client]
              [generator :as gen]]
             [scalardb.core :as scalar]
+            [scalardb.db-extend :refer [wait-for-recovery]]
             [scalardb.transfer-append :as t-append])
   (:import (com.scalar.db.api Result)
            (com.scalar.db.exception.transaction UnknownTransactionStatusException)))
@@ -63,7 +63,7 @@
                       (scalar/try-reconnection-for-2pc! test)
                       (assoc op :type :fail :error (.getMessage e)))))
       :get-all (do
-                 (cassandra/wait-rf-nodes test)
+                 (wait-for-recovery (:db test) test)
                  (if-let [results (t-append/scan-all-records-with-retry
                                    test (:num op))]
                    (assoc op :type :ok

--- a/scalardb/test/scalardb/db_extend_test.clj
+++ b/scalardb/test/scalardb/db_extend_test.clj
@@ -1,0 +1,24 @@
+(ns scalardb.db-extend-test
+  (:require [cassandra.core :as cassandra]
+            [clojure.test :refer [deftest is]]
+            [scalardb.db-extend :as ext]
+            [spy.core :as spy]))
+
+(deftest create-properties-test
+  (with-redefs [cassandra/live-nodes (spy/stub ["n1" "n2" "n3"])]
+    (let [db (ext/extend-db (cassandra/db) :cassandra)
+          properties (ext/create-properties db
+                                            {:isolation-level :serializable
+                                             :serializable-strategy :extra-write})]
+      (is (= "n1,n2,n3"
+             (.getProperty properties "scalar.db.contact_points")))
+      (is (= "cassandra"
+             (.getProperty properties "scalar.db.username")))
+      (is (= "cassandra"
+             (.getProperty properties "scalar.db.password")))
+      (is (= "SERIALIZABLE"
+             (.getProperty properties "scalar.db.isolation_level")))
+      (is (= "EXTRA_WRITE"
+             (.getProperty
+              properties
+              "scalar.db.consensus_commit.serializable_strategy"))))))

--- a/scalardb/test/scalardb/db_extend_test.clj
+++ b/scalardb/test/scalardb/db_extend_test.clj
@@ -17,7 +17,9 @@
       (is (= "cassandra"
              (.getProperty properties "scalar.db.password")))
       (is (= "SERIALIZABLE"
-             (.getProperty properties "scalar.db.isolation_level")))
+             (.getProperty
+              properties
+              "scalar.db.consensus_commit.isolation_level")))
       (is (= "EXTRA_WRITE"
              (.getProperty
               properties

--- a/scalardb/test/scalardb/transfer_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_2pc_test.clj
@@ -2,8 +2,8 @@
   (:require [clojure.test :refer [deftest is]]
             [jepsen.client :as client]
             [jepsen.checker :as checker]
-            [cassandra.core :as cass]
             [scalardb.core :as scalar]
+            [scalardb.core-test :refer [mock-db]]
             [scalardb.transfer :as transfer]
             [scalardb.transfer-2pc :as transfer-2pc]
             [spy.core :as spy])
@@ -205,13 +205,13 @@
 
 (deftest transfer-client-get-all-test
   (binding [test-records (atom {0 1000 1 100 2 10 3 1 4 0})]
-    (with-redefs [cass/wait-rf-nodes (spy/spy)
-                  scalar/check-transaction-connection! (spy/spy)
+    (with-redefs [scalar/check-transaction-connection! (spy/spy)
                   scalar/check-storage-connection! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
       (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
                                  nil nil)
-            result (client/invoke! client {:storage (ref mock-storage)}
+            result (client/invoke! client {:db mock-db
+                                           :storage (ref mock-storage)}
                                    (#'transfer/get-all {:client client}
                                                        nil))]
         (is (spy/called-once? scalar/check-transaction-connection!))
@@ -221,8 +221,7 @@
         (is (= [1000 100 10 1 0] (get-in result [:value :version])))))))
 
 (deftest transfer-client-get-all-fail-test
-  (with-redefs [cass/wait-rf-nodes (spy/spy)
-                cass/exponential-backoff (spy/spy)
+  (with-redefs [scalar/exponential-backoff (spy/spy)
                 scalar/check-transaction-connection! (spy/spy)
                 scalar/check-storage-connection! (spy/spy)
                 scalar/prepare-transaction-service! (spy/spy)
@@ -231,10 +230,11 @@
     (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
                                nil nil)]
       (is (thrown? clojure.lang.ExceptionInfo
-                   (client/invoke! client {:storage (ref mock-storage)}
+                   (client/invoke! client {:db mock-db
+                                           :storage (ref mock-storage)}
                                    (#'transfer/get-all {:client client}
                                                        nil))))
-      (is (spy/called-n-times? cass/exponential-backoff scalar/RETRIES))
+      (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
       (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION))
       (is (spy/called-n-times? scalar/prepare-storage-service! scalar/RETRIES_FOR_RECONNECTION)))))
 

--- a/scalardb/test/scalardb/transfer_append_test.clj
+++ b/scalardb/test/scalardb/transfer_append_test.clj
@@ -2,8 +2,8 @@
   (:require [clojure.test :refer [deftest is]]
             [jepsen.client :as client]
             [jepsen.checker :as checker]
-            [cassandra.core :as cass]
             [scalardb.core :as scalar]
+            [scalardb.core-test :refer [mock-db]]
             [scalardb.transfer-append :as transfer]
             [spy.core :as spy])
   (:import (com.scalar.db.api DistributedTransaction
@@ -192,12 +192,11 @@
                                    {:age 2 :balance 100}
                                    {:age 3 :balance 10}]
                                 2 [{:age 1 :balance 1}]})]
-    (with-redefs [cass/wait-rf-nodes (spy/spy)
-                  scalar/check-transaction-connection! (spy/spy)
+    (with-redefs [scalar/check-transaction-connection! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
       (let [client (client/open! (transfer/->TransferClient (atom false) 3 100)
                                  nil nil)
-            result (client/invoke! client {}
+            result (client/invoke! client {:db mock-db}
                                    (#'transfer/get-all {:client client}
                                                        nil))]
         (is (spy/called-once? scalar/check-transaction-connection!))
@@ -207,18 +206,17 @@
         (is (= [2 3 1] (get-in result [:value :num])))))))
 
 (deftest transfer-client-get-all-fail-test
-  (with-redefs [cass/wait-rf-nodes (spy/spy)
-                cass/exponential-backoff (spy/spy)
+  (with-redefs [scalar/exponential-backoff (spy/spy)
                 scalar/check-transaction-connection! (spy/spy)
                 scalar/prepare-transaction-service! (spy/spy)
                 scalar/start-transaction (spy/stub mock-transaction-throws-exception)]
     (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
                                nil nil)]
       (is (thrown? clojure.lang.ExceptionInfo
-                   (client/invoke! client {}
+                   (client/invoke! client {:db mock-db}
                                    (#'transfer/get-all {:client client}
                                                        nil))))
-      (is (spy/called-n-times? cass/exponential-backoff scalar/RETRIES))
+      (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
       (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION)))))
 
 (deftest transfer-client-check-tx-test


### PR DESCRIPTION
## Description
To support other DBs, clean up Cassandra-dependent code and DB-specific code in `scalardb`

## Related issues and/or PRs
#113

## Changes made
- Separate the Cassandra-dependent code
    - Replace `cassandra-test` with `scalardb-test`
    - Use ScalarDB schema loder
- Add abstract DB-specific functions with `extend-db`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
