### PR TITLE
db/Retry after deletion

### DIFF
--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -31,14 +31,21 @@
       (loop [retries RETRIES]
         (when (zero? retries)
           (throw (ex-info "Failed to set up tables" {:schema schema})))
-        (let [result (try
+        (let [schema (cheshire/generate-string schema)
+              result (try
                        (SchemaLoader/load properties
-                                          (cheshire/generate-string schema)
+                                          schema
                                           options
                                           true)
                        :success
                        (catch Exception e
                          (warn (.getMessage e))
+                         (try
+                           (SchemaLoader/unload properties
+                                                schema
+                                                true)
+                           (catch Exception e
+                             (warn (.getMessage e))))
                          :fail))]
           (when (= result :fail)
             (recur (dec retries))))))))


### PR DESCRIPTION
## Description
In ScalarDB test, retry after deleting the existing tables for the schema loader failure

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
Add table deletion before the table creation retry

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
