### PR TITLE
ScalarDB/Fix type-mismatch operation on `val` column in `elle-append`

### DIFF
--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -11,7 +11,6 @@
   (:import (com.scalar.db.api Get
                               Put)
            (com.scalar.db.io IntValue
-                             TextValue
                              Key)
            (com.scalar.db.exception.transaction
             UnknownTransactionStatusException)))

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -37,7 +37,7 @@
       (Put.)
       (.forNamespace KEYSPACE)
       (.forTable table)
-      (.withValue (TextValue. VALUE value))))
+      (.withValue (IntValue. VALUE value))))
 
 (defn get-value
   [r]

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -11,6 +11,7 @@
   (:import (com.scalar.db.api Get
                               Put)
            (com.scalar.db.io IntValue
+                             TextValue
                              Key)
            (com.scalar.db.exception.transaction
             UnknownTransactionStatusException)))
@@ -21,7 +22,7 @@
 (def ^:const SCHEMA {:transaction true
                      :partition-key [ID]
                      :clustering-key []
-                     :columns {(keyword ID) "INT" (keyword VALUE) "INT"}})
+                     :columns {(keyword ID) "INT" (keyword VALUE) "TEXT"}})
 
 (defn prepare-get
   [table id]
@@ -36,7 +37,7 @@
       (Put.)
       (.forNamespace KEYSPACE)
       (.forTable table)
-      (.withValue (IntValue. VALUE value))))
+      (.withValue (TextValue. VALUE value))))
 
 (defn get-value
   [r]


### PR DESCRIPTION
## Description

When I executed `elle-append` workload in `scalardb` directory, a bunch of IllegalArgumentException happened as follows
```
root@control:/scalar-jepsen/scalardb# lein run test --workload elle-append --nemesis crash --admin join --time-limit 300 --ssh-private-key ~/.ssh/id_rsa

...

2024-02-27 08:33:09,633{GMT}    WARN    [parallel-executor-1] com.scalar.db.transaction.consensuscommit.ParallelExecutor: Failed to run a preparation task. transaction ID: c1b0b7b2-ee3b-4f62-aea2-0dd2b2b30cde
java.lang.IllegalArgumentException: CORE-10017: The column value is not properly specified. Column: TextColumn{name=val, value=2}, Operation: Put{namespace=Optional[jepsen], table=Optional[txn0_1], partitionKey=Key{IntColumn{name=id, value=7, hasNullValue=false}}, clusteringKey=Optional.empty, columns={val=TextColumn{name=val, value=2}, tx_id=TextColumn{name=tx_id, value=c1b0b7b2-ee3b-4f62-aea2-0dd2b2b30cde}, tx_state=IntColumn{name=tx_state, value=1, hasNullValue=false}, tx_prepared_at=BigIntColumn{name=tx_prepared_at, value=1709022789463, hasNullValue=false}, tx_version=IntColumn{name=tx_version, value=1, hasNullValue=false}}, consistency=LINEARIZABLE, condition=Optional[PutIfNotExists{}], implicitPreReadEnabled=false}
        at com.scalar.db.common.checker.OperationChecker.checkColumnsInPut(OperationChecker.java:309)
        at com.scalar.db.common.checker.OperationChecker.check(OperationChecker.java:285)
        at com.scalar.db.storage.cassandra.Cassandra.put(Cassandra.java:134)
        at com.scalar.db.storage.cassandra.Cassandra.mutate(Cassandra.java:161)
        at com.scalar.db.transaction.consensuscommit.CommitHandler.lambda$prepareRecords$0(CommitHandler.java:189)
        at com.scalar.db.transaction.consensuscommit.ParallelExecutor.lambda$executeTasksInParallel$0(ParallelExecutor.java:181)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
2024-02-27 08:33:09,633{GMT}    WARN    [parallel-executor-2] com.scalar.db.transaction.consensuscommit.ParallelExecutor: Failed to run a preparation task. transaction ID: c1b0b7b2-ee3b-4f62-aea2-0dd2b2b30cde
java.lang.IllegalArgumentException: CORE-10017: The column value is not properly specified. Column: TextColumn{name=val, value=1}, Operation: Put{namespace=Optional[jepsen], table=Optional[txn0_2], partitionKey=Key{IntColumn{name=id, value=5, hasNullValue=false}}, clusteringKey=Optional.empty, columns={val=TextColumn{name=val, value=1}, tx_id=TextColumn{name=tx_id, value=c1b0b7b2-ee3b-4f62-aea2-0dd2b2b30cde}, tx_state=IntColumn{name=tx_state, value=1, hasNullValue=false}, tx_prepared_at=BigIntColumn{name=tx_prepared_at, value=1709022789463, hasNullValue=false}, tx_version=IntColumn{name=tx_version, value=1, hasNullValue=false}}, consistency=LINEARIZABLE, condition=Optional[PutIfNotExists{}], implicitPreReadEnabled=false}
 ...

Everything looks good! ヽ('ー`)ノ
```

I noticed the type of `val` column was defined as INT, but the Put operation tried to set the column to TextValue.

## Related issues and/or PRs

https://github.com/scalar-labs/scalar-jepsen/pull/114 might be related?

## Changes made

This PR changes the Put operation to set the column to IntValue to align with the table schema.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

I wondered which type of the column was correct, INT or TEXT, but I followed [elle-write-read](https://github.com/scalar-labs/scalar-jepsen/blob/master/scalardb/src/scalardb/elle_write_read.clj#L23).