### PR TITLE
fix DL runner to use cassandra options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ pom.xml
 */report/**
 */resources/ledger*
 docker/keys/
+.DS_Store
+*/.clj-kondo
+*/.lein-*
+*/.lsp

--- a/scalardl/src/scalardl/runner.clj
+++ b/scalardl/src/scalardl/runner.clj
@@ -56,6 +56,8 @@
   []
   {"test" {:opt-spec (->> opt-spec
                           (into car/cassandra-opt-spec)
+                          (into car/nemesis-opt-spec)
+                          (into car/admin-opt-spec)
                           (into cli/test-opt-spec))
            :opt-fn   (fn [parsed] (-> parsed parse-nodes cli/test-opt-fn))
            :usage    (cli/test-usage)


### PR DESCRIPTION
## Description
When I separated Cassandra option function, I forgot to update the DL runner.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add Cassandra test's `nemesis-opt-spec` and `admin-opt-spec`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
