### PR TITLE
Request transfer transactions in parallel

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -9,8 +9,7 @@
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cheshire "5.12.0"]
-                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"
-                  :exclusions [org.slf4j/*]]]
+                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -9,7 +9,8 @@
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT"]
                  [cheshire "5.12.0"]
-                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"]]
+                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"
+                  :exclusions [org.slf4j/*]]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -192,16 +192,10 @@
   (when-not @(:transaction test)
     (prepare-transaction-service! test)))
 
-(defn try-reconnection-for-transaction!
-  [test]
+(defn try-reconnection!
+  [test prepare-fn]
   (when (= (swap! (:failures test) inc) NUM_FAILURES_FOR_RECONNECTION)
-    (prepare-transaction-service! test)
-    (reset! (:failures test) 0)))
-
-(defn try-reconnection-for-2pc!
-  [test]
-  (when (= (swap! (:failures test) inc) NUM_FAILURES_FOR_RECONNECTION)
-    (prepare-2pc-service! test)
+    (prepare-fn test)
     (reset! (:failures test) 0)))
 
 (defn start-transaction

--- a/scalardb/src/scalardb/elle_append.clj
+++ b/scalardb/src/scalardb/elle_append.clj
@@ -110,7 +110,7 @@
           (swap! (:unknown-tx test) conj (.getId tx))
           (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
         (catch Exception e
-          (scalar/try-reconnection-for-transaction! test)
+          (scalar/try-reconnection! test scalar/prepare-transaction-service!)
           (assoc op :type :fail :error {:crud-error (.getMessage e)})))))
 
   (close! [_ _])

--- a/scalardb/src/scalardb/elle_append_2pc.clj
+++ b/scalardb/src/scalardb/elle_append_2pc.clj
@@ -52,7 +52,7 @@
           (assoc op :type :info :error {:unknown-tx-status (.getId tx1)}))
         (catch Exception e
           (scalar/rollback-txs [tx1 tx2])
-          (scalar/try-reconnection-for-2pc! test)
+          (scalar/try-reconnection! test scalar/prepare-2pc-service!)
           (assoc op :type :fail :error {:crud-error (.getMessage e)})))))
 
   (close! [_ _])

--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -105,7 +105,7 @@
           (swap! (:unknown-tx test) conj (.getId tx))
           (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
         (catch Exception e
-          (scalar/try-reconnection-for-transaction! test)
+          (scalar/try-reconnection! test scalar/prepare-transaction-service!)
           (assoc op :type :fail :error {:crud-error (.getMessage e)})))))
 
   (close! [_ _])

--- a/scalardb/src/scalardb/elle_write_read_2pc.clj
+++ b/scalardb/src/scalardb/elle_write_read_2pc.clj
@@ -44,7 +44,7 @@
           (assoc op :type :info :error {:unknown-tx-status (.getId tx1)}))
         (catch Exception e
           (scalar/rollback-txs [tx1 tx2])
-          (scalar/try-reconnection-for-2pc! test)
+          (scalar/try-reconnection! test scalar/prepare-2pc-service!)
           (assoc op :type :fail :error {:crud-error (.getMessage e)})))))
 
   (close! [_ _])

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -1,5 +1,6 @@
 (ns scalardb.transfer
   (:require [clojure.core.reducers :as r]
+            [clojure.tools.logging :refer [warn]]
             [jepsen
              [client :as client]
              [checker :as checker]
@@ -23,6 +24,7 @@
 
 (def ^:const INITIAL_BALANCE 10000)
 (def ^:const NUM_ACCOUNTS 10)
+(def ^:const MAX_NUM_TXS 8)
 (def ^:private ^:const TOTAL_BALANCE (* NUM_ACCOUNTS INITIAL_BALANCE))
 
 (def ^:const SCHEMA {(keyword (str KEYSPACE \. TABLE))
@@ -86,7 +88,7 @@
   (-> r get-balance (+ amount)))
 
 (defn- tx-transfer
-  [tx {:keys [from to amount]}]
+  [tx from to amount]
   (let [fromResult (.get tx (prepare-get from))
         toResult (.get tx (prepare-get to))]
     (->> (calc-new-balance fromResult (- amount))
@@ -96,6 +98,34 @@
          (prepare-put to)
          (.put tx))
     (.commit tx)))
+
+(defn- try-tx-transfer
+  [test {:keys [from to amount]}]
+  (if-let [tx (scalar/start-transaction test)]
+    (try
+      (tx-transfer tx from to amount)
+      :commit
+      (catch UnknownTransactionStatusException _
+        (swap! (:unknown-tx test) conj (.getId tx))
+        (warn "Unknown transaction: " (.getId tx))
+        :unknown-tx-status)
+      (catch Exception e
+        (warn (.getMessage e))
+        :fail))
+    :start-fail))
+
+(defn exec-transfers
+  "Execute transfers in parallel. Give the transfer function."
+  [test op transfer-fn]
+  (let [results (pmap #(transfer-fn test %) (:value op))]
+    (when (every? :start-fail results)
+      (scalar/try-reconnection-for-transaction! test))
+    (if (some #{:commit} results)
+      ;; return :ok when at least 1 transaction is committed
+      (assoc op :type :ok :value {:results results})
+      ;; :info type could be better in some cases
+      ;; However, our checker doesn't care about the type for now
+      (assoc op :type :fail :error {:results results}))))
 
 (defn- read-record
   "Read a record with a transaction. If read fails, this function returns nil."
@@ -110,41 +140,33 @@
   [test n]
   (scalar/check-transaction-connection! test)
   (scalar/check-storage-connection! test)
-  (scalar/with-retry (fn [test] (scalar/prepare-transaction-service! test) (scalar/prepare-storage-service! test)) test
+  (scalar/with-retry
+    (fn [test]
+      (scalar/prepare-transaction-service! test)
+      (scalar/prepare-storage-service! test))
+    test
     (let [tx (scalar/start-transaction test)
           results (map #(read-record tx @(:storage test) %) (range n))]
       (if (some nil? results) nil results))))
 
-(defrecord TransferClient [initialized? n initial-balance]
+(defrecord TransferClient [initialized?]
   client/Client
   (open! [_ _ _]
-    (TransferClient. initialized? n initial-balance))
+    (TransferClient. initialized?))
 
   (setup! [_ test]
     (locking initialized?
       (when (compare-and-set! initialized? false true)
         (setup-tables test)
         (scalar/prepare-transaction-service! test)
-        (populate-accounts test n initial-balance))))
+        (populate-accounts test NUM_ACCOUNTS INITIAL_BALANCE))))
 
   (invoke! [_ test op]
     (case (:f op)
-      :transfer (if-let [tx (scalar/start-transaction test)]
-                  (try
-                    (tx-transfer tx (:value op))
-                    (assoc op :type :ok)
-                    (catch UnknownTransactionStatusException _
-                      (swap! (:unknown-tx test) conj (.getId tx))
-                      (assoc op :type :info :error {:unknown-tx-status (.getId tx)}))
-                    (catch Exception e
-                      (scalar/try-reconnection-for-transaction! test)
-                      (assoc op :type :fail :error (.getMessage e))))
-                  (do
-                    (scalar/try-reconnection-for-transaction! test)
-                    (assoc op :type :fail :error "Skipped due to no connection")))
+      :transfer (exec-transfers test op try-tx-transfer)
       :get-all (do
                  (wait-for-recovery (:db test) test)
-                 (if-let [results (read-all-with-retry test (:num op))]
+                 (if-let [results (read-all-with-retry test NUM_ACCOUNTS)]
                    (assoc op :type :ok :value {:balance (get-balances results)
                                                :version (get-versions results)})
                    (assoc op :type :fail :error "Failed to get balances")))
@@ -159,25 +181,29 @@
   (teardown! [_ test]
     (scalar/close-all! test)))
 
-(defn- transfer
-  [test _]
-  (let [n (-> test :client :n)]
+(defn- generate-acc-pair
+  [n]
+  (loop []
+    (let [from (rand-int n)
+          to (rand-int n)]
+      (if-not (= from to) [from to] (recur)))))
+
+(defn transfer
+  [_ _]
+  (let [num-txs (inc (rand-int MAX_NUM_TXS))]
     {:type  :invoke
      :f     :transfer
-     :value {:from   (rand-int n)
-             :to     (rand-int n)
-             :amount (+ 1 (rand-int 1000))}}))
-
-(def diff-transfer
-  (gen/filter (fn [op] (not= (-> op :value :from)
-                             (-> op :value :to)))
-              transfer))
+     :value (repeatedly num-txs
+                        (fn []
+                          (let [[from to] (generate-acc-pair NUM_ACCOUNTS)]
+                            {:from from
+                             :to   to
+                             :amount (+ 1 (rand-int 1000))})))}))
 
 (defn get-all
-  [test _]
+  [_ _]
   {:type :invoke
-   :f    :get-all
-   :num  (-> test :client :n)})
+   :f    :get-all})
 
 (defn check-tx
   [_ _]
@@ -187,7 +213,7 @@
 (defn consistency-checker
   []
   (reify checker/Checker
-    (check [_ test history _]
+    (check [_ _ history _]
       (let [read-result (->> history
                              (r/filter #(= :get-all (:f %)))
                              (r/filter identity)
@@ -209,16 +235,18 @@
                                    last
                                    ((fn [x]
                                       (if (= (:type x) :ok) (:value x) 0))))
-            total-ok (->> history
-                          (r/filter op/ok?)
-                          (r/filter #(= :transfer (:f %)))
-                          (r/filter identity)
-                          (into [])
-                          count
-                          (+ checked-committed))
-            expected-version (-> total-ok
-                                 (* 2)                      ; update 2 records per a transfer
-                                 (+ (-> test :client :n)))  ; initial insertions
+            total-commits (->> history
+                               (r/filter op/ok?)
+                               (r/filter #(= :transfer (:f %)))
+                               (r/reduce (fn [cnt op]
+                                           (->> op :value :results
+                                                (filter #{:commit})
+                                                count
+                                                (+ cnt)))
+                                         checked-committed))
+            expected-version (-> total-commits
+                                 (* 2)              ; update 2 records per transfer
+                                 (+ NUM_ACCOUNTS))  ; initial insertions
             bad-version (when-not (= actual-version expected-version)
                           {:type     :wrong-version
                            :expected expected-version
@@ -231,8 +259,8 @@
 
 (defn workload
   [_]
-  {:client (->TransferClient (atom false) NUM_ACCOUNTS INITIAL_BALANCE)
-   :generator [diff-transfer]
+  {:client (->TransferClient (atom false))
+   :generator [transfer]
    :final-generator (gen/phases
                      (gen/once get-all)
                      (gen/once check-tx))

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -117,8 +117,6 @@
   "Execute transfers in parallel. Give the transfer function."
   [test op transfer-fn]
   (let [results (pmap #(transfer-fn test %) (:value op))]
-    (when (every? :start-fail results)
-      (scalar/try-reconnection! test scalar/prepare-transaction-service!))
     (if (some #{:commit} results)
       ;; return :ok when at least 1 transaction is committed
       (assoc op :type :ok :value {:results results})
@@ -192,7 +190,7 @@
 (defn transfer
   [test _]
   (let [num-accs (-> test :client :n)
-        num-txs (inc (rand-int (-> test :client :max-txs)))]
+        num-txs (-> test :client :max-txs rand-int inc)]
     {:type  :invoke
      :f     :transfer
      :value (repeatedly num-txs

--- a/scalardb/src/scalardb/transfer_2pc.clj
+++ b/scalardb/src/scalardb/transfer_2pc.clj
@@ -38,7 +38,7 @@
         (warn "Unknown transaction: " (.getId tx1))
         :unknown-tx-status)
       (catch Exception e
-        (warn "transaction" (.getId tx1) "failed:" (.getMessage e))
+        (warn (.getMessage e))
         :fail))))
 
 (defrecord TransferClient [initialized? n initial-balance max-txs]

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -1,12 +1,13 @@
 (ns scalardb.transfer-append
   (:require [clojure.core.reducers :as r]
-            [clojure.tools.logging :refer [info]]
+            [clojure.tools.logging :refer [info warn]]
             [jepsen
              [client :as client]
              [checker :as checker]
              [generator :as gen]]
             [scalardb.core :as scalar :refer [KEYSPACE]]
-            [scalardb.db-extend :refer [wait-for-recovery]])
+            [scalardb.db-extend :refer [wait-for-recovery]]
+            [scalardb.transfer :as transfer])
   (:import (com.scalar.db.api Put
                               Scan
                               Scan$Ordering
@@ -21,9 +22,6 @@
 (def ^:private ^:const ACCOUNT_ID "account_id")
 (def ^:private ^:const BALANCE "balance")
 (def ^:private ^:const AGE "age")
-(def ^:const INITIAL_BALANCE 10000)
-(def ^:const NUM_ACCOUNTS 10)
-(def ^:private ^:const TOTAL_BALANCE (* NUM_ACCOUNTS INITIAL_BALANCE))
 (def ^:const SCHEMA {(keyword (str KEYSPACE \. TABLE))
                      {:transaction true
                       :partition-key [ACCOUNT_ID]
@@ -100,7 +98,7 @@
   (-> r get-age inc))
 
 (defn- tx-transfer
-  [tx {:keys [from to amount]}]
+  [tx from to amount]
   (let [^Result from-result (scan-for-latest tx (prepare-scan-for-latest from))
         ^Result to-result (scan-for-latest tx (prepare-scan-for-latest to))]
     (info "fromID:" from "the latest age:" (get-age from-result))
@@ -114,6 +112,21 @@
                       (calc-new-balance to-result amount))
          (.put tx))
     (.commit tx)))
+
+(defn- try-tx-transfer
+  [test {:keys [from to amount]}]
+  (if-let [tx (scalar/start-transaction test)]
+    (try
+      (tx-transfer tx from to amount)
+      :commit
+      (catch UnknownTransactionStatusException _
+        (swap! (:unknown-tx test) conj (.getId tx))
+        (warn "Unknown transaction: " (.getId tx))
+        :unknown-tx-status)
+      (catch Exception e
+        (warn (.getMessage e))
+        :fail))
+    :start-fail))
 
 (defn- scan-records
   [tx id]
@@ -129,10 +142,10 @@
           results (map #(scan-records tx %) (range n))]
       (if (some nil? results) nil results))))
 
-(defrecord TransferClient [initialized? n initial-balance]
+(defrecord TransferClient [initialized? n initial-balance max-txs]
   client/Client
   (open! [_ _ _]
-    (TransferClient. initialized? n initial-balance))
+    (TransferClient. initialized? n initial-balance max-txs))
 
   (setup! [_ test]
     (locking initialized?
@@ -143,26 +156,10 @@
 
   (invoke! [_ test op]
     (case (:f op)
-      :transfer (if-let [tx (scalar/start-transaction test)]
-                  (try
-                    (tx-transfer tx (:value op))
-                    (assoc op :type :ok)
-                    (catch UnknownTransactionStatusException _
-                      (swap! (:unknown-tx test) conj (.getId tx))
-                      (assoc op :type :info, :error {:unknown-tx-status (.getId tx)}))
-                    (catch Exception e
-                      (scalar/try-reconnection!
-                       test
-                       scalar/prepare-transaction-service!)
-                      (assoc op :type :fail, :error (.getMessage e))))
-                  (do
-                    (scalar/try-reconnection!
-                     test
-                     scalar/prepare-transaction-service!)
-                    (assoc op :type :fail, :error "Skipped due to no connection")))
+      :transfer (transfer/exec-transfers test op try-tx-transfer)
       :get-all (do
                  (wait-for-recovery (:db test) test)
-                 (if-let [results (scan-all-records-with-retry test (:num op))]
+                 (if-let [results (scan-all-records-with-retry test n)]
                    (assoc op :type, :ok :value {:balance (get-balances results)
                                                 :age (get-ages results)
                                                 :num (get-nums results)})
@@ -177,25 +174,10 @@
   (teardown! [_ test]
     (scalar/close-all! test)))
 
-(defn- transfer
-  [test _]
-  (let [n (-> test :client :n)]
-    {:type  :invoke
-     :f     :transfer
-     :value {:from   (rand-int n)
-             :to     (rand-int n)
-             :amount (+ 1 (rand-int 1000))}}))
-
-(def diff-transfer
-  (gen/filter (fn [op] (not= (-> op :value :from)
-                             (-> op :value :to)))
-              transfer))
-
 (defn get-all
-  [test _]
+  [_ _]
   {:type :invoke
-   :f    :get-all
-   :num  (-> test :client :n)})
+   :f    :get-all})
 
 (defn check-tx
   [_ _]
@@ -205,17 +187,20 @@
 (defn consistency-checker
   []
   (reify checker/Checker
-    (check [_ _ history _]
-      (let [read-result (->> history
+    (check [_ test history _]
+      (let [num-accs (-> test :client :n)
+            initial-balance (-> test :client :initial-balance)
+            total-balance (* num-accs initial-balance)
+            read-result (->> history
                              (r/filter #(= :get-all (:f %)))
                              (into [])
                              last
                              :value)
             actual-balance (->> (:balance read-result)
                                 (reduce +))
-            bad-balance (when-not (= actual-balance TOTAL_BALANCE)
+            bad-balance (when-not (= actual-balance total-balance)
                           {:type     :wrong-balance
-                           :expected TOTAL_BALANCE
+                           :expected total-balance
                            :actual   actual-balance})
             actual-age (->> (:age read-result)
                             (reduce +))
@@ -240,8 +225,11 @@
 
 (defn workload
   [_]
-  {:client (->TransferClient (atom false) NUM_ACCOUNTS INITIAL_BALANCE)
-   :generator [diff-transfer]
+  {:client (->TransferClient (atom false)
+                             transfer/NUM_ACCOUNTS
+                             transfer/INITIAL_BALANCE
+                             transfer/MAX_NUM_TXS)
+   :generator [transfer/transfer]
    :final-generator (gen/phases
                      (gen/once get-all)
                      (gen/once check-tx))

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -164,8 +164,9 @@
                                                 :age (get-ages results)
                                                 :num (get-nums results)})
                    (assoc op :type, :fail, :error "Failed to get all records")))
-      :check-tx (if-let [num-committed (scalar/check-transaction-states test
-                                                                        @(:unknown-tx test))]
+      :check-tx (if-let [num-committed (scalar/check-transaction-states
+                                        test
+                                        @(:unknown-tx test))]
                   (assoc op :type :ok, :value num-committed)
                   (assoc op :type :fail, :error "Failed to check status"))))
 

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -151,10 +151,14 @@
                       (swap! (:unknown-tx test) conj (.getId tx))
                       (assoc op :type :info, :error {:unknown-tx-status (.getId tx)}))
                     (catch Exception e
-                      (scalar/try-reconnection-for-transaction! test)
+                      (scalar/try-reconnection!
+                       test
+                       scalar/prepare-transaction-service!)
                       (assoc op :type :fail, :error (.getMessage e))))
                   (do
-                    (scalar/try-reconnection-for-transaction! test)
+                    (scalar/try-reconnection!
+                     test
+                     scalar/prepare-transaction-service!)
                     (assoc op :type :fail, :error "Skipped due to no connection")))
       :get-all (do
                  (wait-for-recovery (:db test) test)

--- a/scalardb/src/scalardb/transfer_append_2pc.clj
+++ b/scalardb/src/scalardb/transfer_append_2pc.clj
@@ -60,7 +60,7 @@
                              :type :info
                              :error {:unknown-tx-status (.getId tx1)}))
                     (catch Exception e
-                      (scalar/try-reconnection-for-2pc! test)
+                      (scalar/try-reconnection! test scalar/prepare-2pc-service!)
                       (assoc op :type :fail :error (.getMessage e)))))
       :get-all (do
                  (wait-for-recovery (:db test) test)

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -123,13 +123,13 @@
                                                         mock-tx-manager)))]
     (let [test {:transaction (atom nil)
                 :failures (atom 999)}]
-      (scalar/try-reconnection-for-transaction! test)
+      (scalar/try-reconnection! test scalar/prepare-transaction-service!)
       (is (spy/called-once? scalar/prepare-transaction-service!))
       (is (= mock-tx-manager @(:transaction test)))
       (is (= 0 @(:failures test)))
 
       ;; the next one doesn't reconnect
-      (scalar/try-reconnection-for-transaction! test)
+      (scalar/try-reconnection! test scalar/prepare-transaction-service!)
       (is (spy/called-once? scalar/prepare-transaction-service!))
       (is (= 1 @(:failures test))))))
 

--- a/scalardb/test/scalardb/elle_append_2pc_test.clj
+++ b/scalardb/test/scalardb/elle_append_2pc_test.clj
@@ -139,7 +139,7 @@
   (binding [rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-exception)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (elle-append/->AppendClient (atom false))
                                  nil nil)
             result (client/invoke! client
@@ -151,7 +151,7 @@
                                     :value [0 [[:r 1 nil]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/called-once? scalar/try-reconnection-for-2pc!))
+        (is (spy/called-once? scalar/try-reconnection!))
         (is (= 2 @rollback-count))
         (is (= :fail (:type result)))))))
 
@@ -163,7 +163,7 @@
             rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-unknown)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (elle-append/->AppendClient (atom false))
                                  nil nil)
             result (client/invoke! client
@@ -176,7 +176,7 @@
                                     :value [0 [[:r 1 nil] [:append 1 0]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/not-called? scalar/try-reconnection-for-2pc!))
+        (is (spy/not-called? scalar/try-reconnection!))
         (is (= 2 @get-count))
         (is (= 1 @put-count))
         (is (= 2 @prepare-count))

--- a/scalardb/test/scalardb/elle_append_test.clj
+++ b/scalardb/test/scalardb/elle_append_test.clj
@@ -115,7 +115,7 @@
 
 (deftest append-client-invoke-crud-exception-test
   (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-exception)
-                scalar/try-reconnection-for-transaction! (spy/spy)]
+                scalar/try-reconnection! (spy/spy)]
     (let [client (client/open! (elle-append/->AppendClient (atom false))
                                nil nil)
           result (client/invoke! client
@@ -126,14 +126,14 @@
                                   :f :txn
                                   :value [0 [[:r 1 nil]]]})]
       (is (spy/called-once? scalar/start-transaction))
-      (is (spy/called-once? scalar/try-reconnection-for-transaction!))
+      (is (spy/called-once? scalar/try-reconnection!))
       (is (= :fail (:type result))))))
 
 (deftest append-client-invoke-unknown-exception-test
   (binding [get-count (atom 0)
             put-count (atom 0)]
     (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-unknown)
-                  scalar/try-reconnection-for-transaction! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (elle-append/->AppendClient (atom false))
                                  nil nil)
             result (client/invoke! client
@@ -147,7 +147,7 @@
                                             [[:r 1 nil]
                                              [:append 1 0]]]})]
         (is (spy/called-once? scalar/start-transaction))
-        (is (spy/not-called? scalar/try-reconnection-for-transaction!))
+        (is (spy/not-called? scalar/try-reconnection!))
         (is (= 2 @get-count))
         (is (= 1 @put-count))
         (is (= :info (:type result)))

--- a/scalardb/test/scalardb/elle_write_read_2pc_test.clj
+++ b/scalardb/test/scalardb/elle_write_read_2pc_test.clj
@@ -138,7 +138,7 @@
   (binding [rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-exception)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
                                  nil nil)
             result (client/invoke! client
@@ -150,7 +150,7 @@
                                     :value [0 [[:r 1 nil]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/called-once? scalar/try-reconnection-for-2pc!))
+        (is (spy/called-once? scalar/try-reconnection!))
         (is (= 2 @rollback-count))
         (is (= :fail (:type result)))))))
 
@@ -162,7 +162,7 @@
             rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-unknown)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
                                  nil nil)
             result (client/invoke! client
@@ -175,7 +175,7 @@
                                     :value [0 [[:r 1 nil] [:w 1 1]]]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/not-called? scalar/try-reconnection-for-2pc!))
+        (is (spy/not-called? scalar/try-reconnection!))
         (is (= 2 @get-count))
         (is (= 1 @put-count))
         (is (= 2 @prepare-count))

--- a/scalardb/test/scalardb/elle_write_read_test.clj
+++ b/scalardb/test/scalardb/elle_write_read_test.clj
@@ -114,7 +114,7 @@
 
 (deftest write-read-client-invoke-crud-exception-test
   (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-exception)
-                scalar/try-reconnection-for-transaction! (spy/spy)]
+                scalar/try-reconnection! (spy/spy)]
     (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
                                nil nil)
           result (client/invoke! client
@@ -125,14 +125,14 @@
                                   :f :txn
                                   :value [0 [[:r 1 nil]]]})]
       (is (spy/called-once? scalar/start-transaction))
-      (is (spy/called-once? scalar/try-reconnection-for-transaction!))
+      (is (spy/called-once? scalar/try-reconnection!))
       (is (= :fail (:type result))))))
 
 (deftest write-read-client-invoke-unknown-exception-test
   (binding [get-count (atom 0)
             put-count (atom 0)]
     (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-unknown)
-                  scalar/try-reconnection-for-transaction! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (elle-wr/->WriteReadClient (atom false))
                                  nil nil)
             result (client/invoke! client
@@ -146,7 +146,7 @@
                                             [[:r 1 nil]
                                              [:w 1 1]]]})]
         (is (spy/called-once? scalar/start-transaction))
-        (is (spy/not-called? scalar/try-reconnection-for-transaction!))
+        (is (spy/not-called? scalar/try-reconnection!))
         (is (= 2 @get-count))
         (is (= 1 @put-count))
         (is (= :info (:type result)))

--- a/scalardb/test/scalardb/transfer_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_2pc_test.clj
@@ -117,7 +117,7 @@
                   scalar/prepare-2pc-service! (spy/spy)
                   scalar/prepare-transaction-service! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
-      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                  nil nil)]
         (client/setup! client nil)
         (is (true? @(:initialized? client)))
@@ -142,13 +142,13 @@
             commit-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc)
                   scalar/join-2pc (spy/stub mock-2pc)]
-      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                  nil nil)
             result (client/invoke! client
                                    nil
                                    {:type :invoke
                                     :f :transfer
-                                    :value {:from 0 :to 1 :amount 10}})]
+                                    :value [{:from 0 :to 1 :amount 10}]})]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
         (is (= 2 @get-count))
@@ -163,16 +163,16 @@
   (binding [rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-exception)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
-      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+                  scalar/try-reconnection! (spy/spy)]
+      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                  nil nil)
             result (client/invoke! client
-                                   nil
+                                   {:failures (atom 0)}
                                    (#'transfer/transfer {:client client}
                                                         nil))]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/called-once? scalar/try-reconnection-for-2pc!))
+        (is (spy/called-once? scalar/try-reconnection!))
         (is (= 2 @rollback-count))
         (is (= :fail (:type result)))))))
 
@@ -184,31 +184,31 @@
             rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-unknown)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
-      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+                  scalar/try-reconnection! (spy/spy)]
+      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                  nil nil)
             result (client/invoke! client
-                                   {:unknown-tx (atom #{})}
+                                   {:unknown-tx (atom #{})
+                                    :failures (atom 0)}
                                    (#'transfer/transfer {:client client}
                                                         nil))]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/not-called? scalar/try-reconnection-for-2pc!))
+        (is (spy/called-once? scalar/try-reconnection!))
         (is (= 2 @get-count))
         (is (= 2 @put-count))
         (is (= 2 @prepare-count))
         (is (= 2 @validate-count))
         (is (= 0 @rollback-count))
-        (is (= :info (:type result)))
-        (is (= "unknown-state-tx" (get-in result
-                                          [:error :unknown-tx-status])))))))
+        (is (= :fail (:type result)))
+        (is (= [:unknown-tx-status] (get-in result [:error :results])))))))
 
 (deftest transfer-client-get-all-test
   (binding [test-records (atom {0 1000 1 100 2 10 3 1 4 0})]
     (with-redefs [scalar/check-transaction-connection! (spy/spy)
                   scalar/check-storage-connection! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
-      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+      (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                  nil nil)
             result (client/invoke! client {:db mock-db
                                            :storage (ref mock-storage)}
@@ -227,7 +227,7 @@
                 scalar/prepare-transaction-service! (spy/spy)
                 scalar/prepare-storage-service! (spy/spy)
                 scalar/start-transaction (spy/stub mock-transaction-throws-exception)]
-    (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                nil nil)]
       (is (thrown? clojure.lang.ExceptionInfo
                    (client/invoke! client {:db mock-db
@@ -240,7 +240,7 @@
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]
-    (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                nil nil)
           result (client/invoke! client {:unknown-tx (atom #{"tx1"})}
                                  (#'transfer/check-tx {:client client}
@@ -251,7 +251,7 @@
 
 (deftest transfer-client-check-tx-fail-test
   (with-redefs [scalar/check-transaction-states (spy/stub nil)]
-    (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 5 100 1)
                                nil nil)
           result (client/invoke! client {:unknown-tx (atom #{"tx1"})}
                                  (#'transfer/check-tx {:client client}
@@ -260,20 +260,20 @@
       (is (= :fail (:type result))))))
 
 (def correct-history
-  [{:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :fail :f :transfer :error {:unknown-tx-status "unknown-state-tx"}}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
+  [{:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :fail :f :transfer :error {:results [:unknown-tx-status]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
    {:type :ok :f :get-all :value {:balance [10120 10140 9980 9760 10000
                                             10500 9820 8700 10620 10360]
                                   :version [2 3 2 3 1 2 2 4 2 3]}}
    {:type :ok :f :check-tx :value 1}])
 
 (deftest consistency-checker-test
-  (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 10 10000)
+  (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 10 10000 1)
                              nil nil)
         checker (#'transfer/consistency-checker)
         result (checker/check checker {:client client} correct-history nil)]
@@ -284,20 +284,20 @@
     (is (nil? (:bad-version result)))))
 
 (def bad-history
-  [{:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :fail :f :transfer :error {:unknown-tx-status "unknown-state-tx"}}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
+  [{:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :fail :f :transfer :error {:results [:unknown-tx-status]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
    {:type :ok :f :get-all :value {:balance [10120 10140 9980 9760 10001
                                             10500 9820 8700 10620 10360]
                                   :version [2 3 2 3 1 2 2 4 2 3]}}
    {:type :fail :f :check-tx}])
 
 (deftest consistency-checker-fail-test
-  (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 10 10000)
+  (let [client (client/open! (transfer-2pc/->TransferClient (atom false) 10 10000 1)
                              nil nil)
         checker (#'transfer/consistency-checker)
         result (checker/check checker {:client client} bad-history nil)]

--- a/scalardb/test/scalardb/transfer_append_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_append_2pc_test.clj
@@ -174,7 +174,7 @@
   (binding [rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-exception)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (t-append-2pc/->TransferClient (atom false) 5 100)
                                  nil nil)
             result (client/invoke! client
@@ -183,7 +183,7 @@
                                                         nil))]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/called-once? scalar/try-reconnection-for-2pc!))
+        (is (spy/called-once? scalar/try-reconnection!))
         (is (= 2 @rollback-count))
         (is (= :fail (:type result)))))))
 
@@ -195,7 +195,7 @@
             rollback-count (atom 0)]
     (with-redefs [scalar/start-2pc (spy/stub mock-2pc-throws-unknown)
                   scalar/join-2pc (spy/stub mock-2pc)
-                  scalar/try-reconnection-for-2pc! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (t-append-2pc/->TransferClient (atom false) 5 100)
                                  nil nil)
             result (client/invoke! client
@@ -204,7 +204,7 @@
                                                         nil))]
         (is (spy/called-once? scalar/start-2pc))
         (is (spy/called-once? scalar/join-2pc))
-        (is (spy/not-called? scalar/try-reconnection-for-2pc!))
+        (is (spy/not-called? scalar/try-reconnection!))
         (is (= 2 @scan-count))
         (is (= 2 @put-count))
         (is (= 2 @prepare-count))

--- a/scalardb/test/scalardb/transfer_append_test.clj
+++ b/scalardb/test/scalardb/transfer_append_test.clj
@@ -4,6 +4,7 @@
             [jepsen.checker :as checker]
             [scalardb.core :as scalar]
             [scalardb.core-test :refer [mock-db]]
+            [scalardb.transfer :as t]
             [scalardb.transfer-append :as transfer]
             [spy.core :as spy])
   (:import (com.scalar.db.api DistributedTransaction
@@ -87,7 +88,7 @@
     (with-redefs [scalar/setup-transaction-tables (spy/spy)
                   scalar/prepare-transaction-service! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
-      (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+      (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                  nil nil)]
         (client/setup! client nil)
         (is (true? @(:initialized? client)))
@@ -113,7 +114,7 @@
     (with-redefs [scalar/setup-transaction-tables (spy/spy)
                   scalar/prepare-transaction-service! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction-throws-exception)]
-      (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+      (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                  nil nil)]
         (is (thrown? CrudException (client/setup! client nil)))))))
 
@@ -124,13 +125,13 @@
             put-count (atom 0)
             commit-count (atom 0)]
     (with-redefs [scalar/start-transaction (spy/stub mock-transaction)]
-      (let [client (client/open! (transfer/->TransferClient (atom false) 2 100)
+      (let [client (client/open! (transfer/->TransferClient (atom false) 2 100 1)
                                  nil nil)
             result (client/invoke! client
                                    nil
                                    {:type :invoke
                                     :f :transfer
-                                    :value {:from 0 :to 1 :amount 10}})]
+                                    :value [{:from 0 :to 1 :amount 10}]})]
         (is (spy/called-once? scalar/start-transaction))
         (is (= 2 @scan-count))
         (is (= 2 @put-count))
@@ -143,12 +144,11 @@
 (deftest transfer-client-transfer-no-tx-test
   (with-redefs [scalar/start-transaction (spy/stub nil)
                 scalar/try-reconnection! (spy/spy)]
-    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                nil nil)
           result (client/invoke! client
                                  nil
-                                 (#'transfer/transfer {:client client}
-                                                      nil))]
+                                 (t/transfer {:client client} nil))]
       (is (spy/called-once? scalar/start-transaction))
       (is (spy/called-once? scalar/try-reconnection!))
       (is (= :fail (:type result))))))
@@ -156,12 +156,11 @@
 (deftest transfer-client-transfer-crud-exception-test
   (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-exception)
                 scalar/try-reconnection! (spy/spy)]
-    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                nil nil)
           result (client/invoke! client
                                  nil
-                                 (#'transfer/transfer {:client client}
-                                                      nil))]
+                                 (t/transfer {:client client} nil))]
       (is (spy/called-once? scalar/start-transaction))
       (is (spy/called-once? scalar/try-reconnection!))
       (is (= :fail (:type result))))))
@@ -171,19 +170,17 @@
             put-count (atom 0)]
     (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-unknown)
                   scalar/try-reconnection! (spy/spy)]
-      (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+      (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                  nil nil)
             result (client/invoke! client
                                    {:unknown-tx (atom #{})}
-                                   (#'transfer/transfer {:client client}
-                                                        nil))]
+                                   (t/transfer {:client client} nil))]
         (is (spy/called-once? scalar/start-transaction))
-        (is (spy/not-called? scalar/try-reconnection!))
+        (is (spy/called-once? scalar/try-reconnection!))
         (is (= 2 @scan-count))
         (is (= 2 @put-count))
-        (is (= :info (:type result)))
-        (is (= "unknown-state-tx" (get-in result
-                                          [:error :unknown-tx-status])))))))
+        (is (= :fail (:type result)))
+        (is (= '(:unknown-tx-status) (get-in result [:error :results])))))))
 
 (deftest transfer-client-get-all-test
   (binding [test-records (atom {0 [{:age 1 :balance 0}
@@ -194,11 +191,10 @@
                                 2 [{:age 1 :balance 1}]})]
     (with-redefs [scalar/check-transaction-connection! (spy/spy)
                   scalar/start-transaction (spy/stub mock-transaction)]
-      (let [client (client/open! (transfer/->TransferClient (atom false) 3 100)
+      (let [client (client/open! (transfer/->TransferClient (atom false) 3 100 1)
                                  nil nil)
             result (client/invoke! client {:db mock-db}
-                                   (#'transfer/get-all {:client client}
-                                                       nil))]
+                                   (transfer/get-all {:client client} nil))]
         (is (spy/called-once? scalar/check-transaction-connection!))
         (is (= :ok (:type result)))
         (is (= [1000 10 1] (get-in result [:value :balance])))
@@ -210,44 +206,41 @@
                 scalar/check-transaction-connection! (spy/spy)
                 scalar/prepare-transaction-service! (spy/spy)
                 scalar/start-transaction (spy/stub mock-transaction-throws-exception)]
-    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                nil nil)]
       (is (thrown? clojure.lang.ExceptionInfo
                    (client/invoke! client {:db mock-db}
-                                   (#'transfer/get-all {:client client}
-                                                       nil))))
+                                   (transfer/get-all {:client client} nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
       (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION)))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]
-    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                nil nil)
           result (client/invoke! client {:unknown-tx (atom #{"tx1"})}
-                                 (#'transfer/check-tx {:client client}
-                                                      nil))]
+                                 (transfer/check-tx {:client client} nil))]
       (is (spy/called-once? scalar/check-transaction-states))
       (is (= :ok (:type result)))
       (is (= 1 (:value result))))))
 
 (deftest transfer-client-check-tx-fail-test
   (with-redefs [scalar/check-transaction-states (spy/stub nil)]
-    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
+    (let [client (client/open! (transfer/->TransferClient (atom false) 5 100 1)
                                nil nil)
           result (client/invoke! client {:unknown-tx (atom #{"tx1"})}
-                                 (#'transfer/check-tx {:client client}
-                                                      nil))]
+                                 (transfer/check-tx {:client client} nil))]
       (is (spy/called-once? scalar/check-transaction-states))
       (is (= :fail (:type result))))))
 
 (def correct-history
-  [{:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :fail :f :transfer :error {:unknown-tx-status "unknown-state-tx"}}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
+  [{:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :fail :f :transfer :error {:results [:unknown-tx-status]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
    {:type :ok :f :get-all :value {:balance [10120 10140 9980 9760 10000
                                             10500 9820 8700 10620 10360]
                                   :age [2 3 2 3 1 2 2 4 2 3]
@@ -255,9 +248,9 @@
    {:type :ok :f :check-tx :value 1}])
 
 (deftest consistency-checker-test
-  (let [client (client/open! (transfer/->TransferClient (atom false) 10 10000)
+  (let [client (client/open! (transfer/->TransferClient (atom false) 10 10000 1)
                              nil nil)
-        checker (#'transfer/consistency-checker)
+        checker (transfer/consistency-checker)
         result (checker/check checker {:client client} correct-history nil)]
     (is (true? (:valid? result)))
     (is (= 24 (:total-age result)))
@@ -266,13 +259,13 @@
     (is (nil? (:bad-version result)))))
 
 (def bad-history
-  [{:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :fail :f :transfer :error {:unknown-tx-status "unknown-state-tx"}}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
-   {:type :ok :f :transfer}
+  [{:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :fail :f :transfer :error {:results [:unknown-tx-status]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
+   {:type :ok :f :transfer :value {:results [:commit]}}
    {:type :ok :f :get-all :value {:balance [10120 10140 9980 9760 10001
                                             10500 9820 8700 10620 10360]
                                   :age [2 3 2 3 1 2 2 4 2 3]
@@ -280,9 +273,9 @@
    {:type :fail :f :check-tx}])
 
 (deftest consistency-checker-fail-test
-  (let [client (client/open! (transfer/->TransferClient (atom false) 10 10000)
+  (let [client (client/open! (transfer/->TransferClient (atom false) 10 10000 1)
                              nil nil)
-        checker (#'transfer/consistency-checker)
+        checker (transfer/consistency-checker)
         result (checker/check checker {:client client} bad-history nil)]
     (is (false? (:valid? result)))
     (is (= 24 (:total-age result)))

--- a/scalardb/test/scalardb/transfer_append_test.clj
+++ b/scalardb/test/scalardb/transfer_append_test.clj
@@ -142,7 +142,7 @@
 
 (deftest transfer-client-transfer-no-tx-test
   (with-redefs [scalar/start-transaction (spy/stub nil)
-                scalar/try-reconnection-for-transaction! (spy/spy)]
+                scalar/try-reconnection! (spy/spy)]
     (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
                                nil nil)
           result (client/invoke! client
@@ -150,12 +150,12 @@
                                  (#'transfer/transfer {:client client}
                                                       nil))]
       (is (spy/called-once? scalar/start-transaction))
-      (is (spy/called-once? scalar/try-reconnection-for-transaction!))
+      (is (spy/called-once? scalar/try-reconnection!))
       (is (= :fail (:type result))))))
 
 (deftest transfer-client-transfer-crud-exception-test
   (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-exception)
-                scalar/try-reconnection-for-transaction! (spy/spy)]
+                scalar/try-reconnection! (spy/spy)]
     (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
                                nil nil)
           result (client/invoke! client
@@ -163,14 +163,14 @@
                                  (#'transfer/transfer {:client client}
                                                       nil))]
       (is (spy/called-once? scalar/start-transaction))
-      (is (spy/called-once? scalar/try-reconnection-for-transaction!))
+      (is (spy/called-once? scalar/try-reconnection!))
       (is (= :fail (:type result))))))
 
 (deftest transfer-client-transfer-unknown-exception-test
   (binding [scan-count (atom 0)
             put-count (atom 0)]
     (with-redefs [scalar/start-transaction (spy/stub mock-transaction-throws-unknown)
-                  scalar/try-reconnection-for-transaction! (spy/spy)]
+                  scalar/try-reconnection! (spy/spy)]
       (let [client (client/open! (transfer/->TransferClient (atom false) 5 100)
                                  nil nil)
             result (client/invoke! client
@@ -178,7 +178,7 @@
                                    (#'transfer/transfer {:client client}
                                                         nil))]
         (is (spy/called-once? scalar/start-transaction))
-        (is (spy/not-called? scalar/try-reconnection-for-transaction!))
+        (is (spy/not-called? scalar/try-reconnection!))
         (is (= 2 @scan-count))
         (is (= 2 @put-count))
         (is (= :info (:type result)))


### PR DESCRIPTION
## Description
Each worker's ScalarDB transaction service requested transactions one by one though there are multiple workers.
This PR changes the transaction request to execute multiple transactions at once.
We can test concurrent transactions in more practical cases, especially for the group commit.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made

- Generate multiple transfers with `transfer`
- Set `max-num-txs` to request transactions at once
- Execute transactions in parallel in a worker
- Modify the checkers to confirm the number of succeeded transactions

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
