### PR TITLE
Catch an exception in get-all

### DIFF
--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -127,19 +127,16 @@
         (assoc op :type :fail :error {:results results})))))
 
 (defn- read-record
-  "Read a record with a transaction. If read fails, this function returns nil."
+  "Read a record with a transaction. If read fails, an exception is thrown."
   [tx storage i]
-  (try
-    ;; Need Storage API to read the transaction metadata
-    (let [tx-result (.get tx (prepare-get i))
-          result (.get storage (prepare-get i))]
-      ;; Put the same balance to check conflicts with in-flight transactions
-      (->> (calc-new-balance tx-result 0)
-           (prepare-put i)
-           (.put tx))
-      result)
-    (catch CrudException _ nil)
-    (catch ExecutionException _ nil)))
+  ;; Need Storage API to read the transaction metadata
+  (let [tx-result (.get tx (prepare-get i))
+        result (.get storage (prepare-get i))]
+    ;; Put the same balance to check conflicts with in-flight transactions
+    (->> (calc-new-balance tx-result 0)
+         (prepare-put i)
+         (.put tx))
+    result))
 
 (defn read-all-with-retry
   [test n]
@@ -150,15 +147,16 @@
       (scalar/prepare-transaction-service! test)
       (scalar/prepare-storage-service! test))
     test
-    (let [tx (scalar/start-transaction test)
-          results (doall (map #(read-record tx @(:storage test) %) (range n)))]
-      (try
+    (try
+      (let [tx (scalar/start-transaction test)
+            results (doall (map #(read-record tx @(:storage test) %)
+                                (range n)))]
         (.commit tx)
-        (if (some nil? results) nil results)
-        (catch Exception e
-          ;; The transaction conflicted
-          (warn (.getMessage e))
-          nil)))))
+        results)
+      (catch Exception e
+        ;; The transaction conflicted
+        (warn (.getMessage e))
+        nil))))
 
 (defrecord TransferClient [initialized? n initial-balance max-txs]
   client/Client

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -14,9 +14,7 @@
                               Result)
            (com.scalar.db.io IntValue
                              Key)
-           (com.scalar.db.exception.storage ExecutionException)
-           (com.scalar.db.exception.transaction CrudException
-                                                UnknownTransactionStatusException)))
+           (com.scalar.db.exception.transaction UnknownTransactionStatusException)))
 
 (def ^:private ^:const TABLE "transfer")
 (def ^:private ^:const ACCOUNT_ID "account_id")

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -13,8 +13,7 @@
                               Scan$Ordering
                               Scan$Ordering$Order
                               Result)
-           (com.scalar.db.exception.transaction CrudException
-                                                UnknownTransactionStatusException)
+           (com.scalar.db.exception.transaction UnknownTransactionStatusException)
            (com.scalar.db.io IntValue
                              Key)))
 

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -25,7 +25,9 @@
       (condp = column
         "tx_id" (Optional/of (TextValue. column id))
         "tx_created_at" (Optional/of (BigIntValue. column (long 1566376246)))
-        "tx_state" (Optional/of (IntValue. column (Integer/parseInt id)))))))
+        "tx_state" (Optional/of (IntValue. column (Integer/parseInt id)))
+        ;; for the coordinator table
+        "tx_child_ids" (Optional/empty)))))
 
 (def mock-db
   (reify


### PR DESCRIPTION
## Description
In `transfer` and `transfer-append` tests in ScalarDB tests, `get-all` which reads all the final state misbehaved.
The dummy writes were committed even though the read failed due to conflicts. Then the `get-all` transaction was retried.
It caused the unexpected version increasing. That's why the check phase failed.

## Related issues and/or PRs
Daily Jepsen test failed

## Changes made
- Catch the exceptions when transaction reads

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
