### PR TITLE
Custom configuration for ScalarDB tests

### DIFF
--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -122,7 +122,10 @@
 
    (cli/repeated-opt nil "--consistency-model CONSISTENCY_MODEL"
                      "consistency model to be checked"
-                     ["snapshot-isolation"])])
+                     ["snapshot-isolation"])
+
+   [nil "--config-file CONFIG_FILE" "ScalarDB config file"
+    :default ""]])
 
 (defn- test-name
   [workload-key faults admin]


### PR DESCRIPTION
## Description
Add `--config-file` option for ScalarDB tests.
We can run the tests with the custom properties file of ScalarDB.
  - When the file path is invalid, the test failed
  - Other options like the isolation level will be ignored when the config file is given
## Related issues and/or PRs

## Changes made
- Add `--config-file`
- Load the config when the file path isn't empty or nil

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
