### PR TITLE
Update the README files under `scalardb` and `scalardl` directories

### DIFF
--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -21,7 +21,7 @@ The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar
     # in jepsen-control
 
     $ cd ${SCALAR_JEPSEN}/scalardb
-    $ lein run test --workload transfer --nemesis crash --admin join --time-limit 300
+    $ lein run test --workload transfer --nemesis crash --admin join --time-limit 300 --ssh-private-key ~/.ssh/id_rsa
     ```
 
   - For elle-* tests, `graphviz` package is required in jepsen-control. You can install it with `apt-get install graphviz`

--- a/scalardb/README.md
+++ b/scalardb/README.md
@@ -1,6 +1,6 @@
-# Jepsen tests for Scalar DB
+# Jepsen tests for ScalarDB
 
-This guide will teach you how to run Jepsen tests for Scalar DB.
+This guide will teach you how to run Jepsen tests for ScalarDB.
 The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar-labs/scalar-jepsen/tree/cassandra).
 
 ## How to test
@@ -15,7 +15,7 @@ The current tests use [Cassandra test tools in Jepsen](https://github.com/scalar
     $ lein install
     ```
 
-3. Run a test of Scalar DB
+3. Run a test of ScalarDB
 
     ```
     # in jepsen-control

--- a/scalardl/README.md
+++ b/scalardl/README.md
@@ -1,10 +1,10 @@
-# Jepsen tests for Scalar DL
+# Jepsen tests for ScalarDL
 
-The Scalar DL Jepsen tests make use of the [Cassandra Jepsen tests](https://github.com/scalar-labs/scalar-jepsen/tree/master/cassandra).
+The ScalarDL Jepsen tests make use of the [Cassandra Jepsen tests](https://github.com/scalar-labs/scalar-jepsen/tree/master/cassandra).
 
 ## How to run a test
-1. Get Scalar DL
-  - Scalar DL is licensed under commercial license only
+1. Get ScalarDL
+  - ScalarDL is licensed under commercial license only
     - A test checks `resources/ledger.tar` as default
     - You can specify the DL archive by `--ledger-tarball` option
   - A certificate and a private key for a sample is stored in `resources`
@@ -22,7 +22,7 @@ The Scalar DL Jepsen tests make use of the [Cassandra Jepsen tests](https://gith
     $ lein install
     ```
 
-4. Run a Scalar DL Jepsen test
+4. Run a ScalarDL Jepsen test
 
     ```
     # in jepsen-control


### PR DESCRIPTION
## Description

I noticed there is room to improve the README files under `scalardb` and `scalardl` directories. This PR updates the files.

## Related issues and/or PRs

None

## Changes made

- Add missing necessary option `--ssh-private-key` option to the example command in `scalardb/README.md`
  - Without the option, I failed to run the Jepsen test
  - (Should I add it to `scalardl/README.md` as well?)
- Replace `Scalar DB` with `ScalarDB` and `Scalar DL` with `ScalarDL`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None