### PR TITLE
Improve retry for `scalardb` test

### DIFF
--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -12,7 +12,7 @@
                                   StorageFactory)
            (com.scalar.db.transaction.consensuscommit Coordinator)))
 
-(def ^:const RETRIES 8)
+(def ^:const RETRIES 20)
 (def ^:const RETRIES_FOR_RECONNECTION 3)
 (def ^:private ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
 (def ^:private ^:const MAX_WAIT_MILLIS 32000)

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -15,15 +15,20 @@
 (def ^:const RETRIES 8)
 (def ^:const RETRIES_FOR_RECONNECTION 3)
 (def ^:private ^:const NUM_FAILURES_FOR_RECONNECTION 1000)
+(def ^:private ^:const MAX_WAIT_MILLIS 32000)
 (def ^:const INITIAL_TABLE_ID 1)
 (def ^:const DEFAULT_TABLE_COUNT 3)
 
 (def ^:const KEYSPACE "jepsen")
 (def ^:const VERSION "tx_version")
 
+(defn compute-exponential-backoff
+  [r]
+  (min MAX_WAIT_MILLIS (reduce * 1000 (repeat r 2))))
+
 (defn exponential-backoff
   [r]
-  (Thread/sleep (reduce * 1000 (repeat r 2))))
+  (Thread/sleep (compute-exponential-backoff r)))
 
 (defn- get-cassandra-schema
   "Only the current test schemata are covered

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -103,7 +103,7 @@
                 scalar/create-service-instance (spy/stub nil)]
     (let [test {:db mock-db :storage (atom nil)}]
       (scalar/prepare-storage-service! test)
-      (is (spy/called-n-times? scalar/exponential-backoff 8))
+      (is (spy/called-n-times? scalar/exponential-backoff 20))
       (is (nil? @(:storage test))))))
 
 (deftest check-connection-test
@@ -150,8 +150,8 @@
     (let [test {:storage (atom mock-storage)}]
       (is (thrown? clojure.lang.ExceptionInfo
                    (scalar/check-transaction-states test #{"tx"})))
-      (is (spy/called-n-times? scalar/exponential-backoff 8))
-      (is (spy/called-n-times? scalar/prepare-storage-service! 3)))))
+      (is (spy/called-n-times? scalar/exponential-backoff 20))
+      (is (spy/called-n-times? scalar/prepare-storage-service! 7)))))
 
 (deftest compute-exponential-backoff-test
   (is (= 2000 (scalar/compute-exponential-backoff 1)))

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -103,7 +103,7 @@
                 scalar/create-service-instance (spy/stub nil)]
     (let [test {:db mock-db :storage (atom nil)}]
       (scalar/prepare-storage-service! test)
-      (is (spy/called-n-times? scalar/exponential-backoff 20))
+      (is (spy/called-n-times? scalar/exponential-backoff scalardb.core/RETRIES))
       (is (nil? @(:storage test))))))
 
 (deftest check-connection-test
@@ -150,8 +150,9 @@
     (let [test {:storage (atom mock-storage)}]
       (is (thrown? clojure.lang.ExceptionInfo
                    (scalar/check-transaction-states test #{"tx"})))
-      (is (spy/called-n-times? scalar/exponential-backoff 20))
-      (is (spy/called-n-times? scalar/prepare-storage-service! 7)))))
+      (is (spy/called-n-times? scalar/exponential-backoff scalardb.core/RETRIES))
+      (is (spy/called-n-times? scalar/prepare-storage-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))))
 
 (deftest compute-exponential-backoff-test
   (is (= 2000 (scalar/compute-exponential-backoff 1)))

--- a/scalardb/test/scalardb/core_test.clj
+++ b/scalardb/test/scalardb/core_test.clj
@@ -152,3 +152,9 @@
                    (scalar/check-transaction-states test #{"tx"})))
       (is (spy/called-n-times? scalar/exponential-backoff 8))
       (is (spy/called-n-times? scalar/prepare-storage-service! 3)))))
+
+(deftest compute-exponential-backoff-test
+  (is (= 2000 (scalar/compute-exponential-backoff 1)))
+  (is (= 4000 (scalar/compute-exponential-backoff 2)))
+  (is (= 32000 (scalar/compute-exponential-backoff 5)))
+  (is (= 32000 (scalar/compute-exponential-backoff 10))))

--- a/scalardb/test/scalardb/transfer_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_2pc_test.clj
@@ -236,9 +236,9 @@
                                                        nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
       (is (spy/called-n-times? scalar/prepare-transaction-service!
-                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1)))
       (is (spy/called-n-times? scalar/prepare-storage-service!
-                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1)))))
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]

--- a/scalardb/test/scalardb/transfer_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_2pc_test.clj
@@ -235,8 +235,10 @@
                                    (#'transfer/get-all {:client client}
                                                        nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
-      (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION))
-      (is (spy/called-n-times? scalar/prepare-storage-service! scalar/RETRIES_FOR_RECONNECTION)))))
+      (is (spy/called-n-times? scalar/prepare-transaction-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))
+      (is (spy/called-n-times? scalar/prepare-storage-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1)))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]

--- a/scalardb/test/scalardb/transfer_append_2pc_test.clj
+++ b/scalardb/test/scalardb/transfer_append_2pc_test.clj
@@ -242,7 +242,8 @@
                    (client/invoke! client {:db mock-db}
                                    (transfer/get-all {:client client} nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
-      (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION)))))
+      (is (spy/called-n-times? scalar/prepare-transaction-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]

--- a/scalardb/test/scalardb/transfer_append_test.clj
+++ b/scalardb/test/scalardb/transfer_append_test.clj
@@ -212,7 +212,8 @@
                    (client/invoke! client {:db mock-db}
                                    (transfer/get-all {:client client} nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
-      (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION)))))
+      (is (spy/called-n-times? scalar/prepare-transaction-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]

--- a/scalardb/test/scalardb/transfer_test.clj
+++ b/scalardb/test/scalardb/transfer_test.clj
@@ -205,8 +205,10 @@
                                    (#'transfer/get-all {:client client}
                                                        nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
-      (is (spy/called-n-times? scalar/prepare-transaction-service! scalar/RETRIES_FOR_RECONNECTION))
-      (is (spy/called-n-times? scalar/prepare-storage-service! scalar/RETRIES_FOR_RECONNECTION)))))
+      (is (spy/called-n-times? scalar/prepare-transaction-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))
+      (is (spy/called-n-times? scalar/prepare-storage-service!
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1)))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]

--- a/scalardb/test/scalardb/transfer_test.clj
+++ b/scalardb/test/scalardb/transfer_test.clj
@@ -206,9 +206,9 @@
                                                        nil))))
       (is (spy/called-n-times? scalar/exponential-backoff scalar/RETRIES))
       (is (spy/called-n-times? scalar/prepare-transaction-service!
-                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1)))
       (is (spy/called-n-times? scalar/prepare-storage-service!
-                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1)))))
+                               (+ (quot scalar/RETRIES scalar/RETRIES_FOR_RECONNECTION) 1))))))
 
 (deftest transfer-client-check-tx-test
   (with-redefs [scalar/check-transaction-states (spy/stub 1)]


### PR DESCRIPTION
## Description

Recently, `scalardb.transfer$read_all_with_retry` often failed when there are many records to be lazy-recovered more than the max retry (8). To mitigate the failure, this PR increases the max retry. But just increasing it causes too long wait duration. For instance, increasing the max retry up to 10 will result in 1024 seconds wait. So, this PR also introduces an upper limit of wait duration (32 seconds) since too long retry duration doesn't make sense basically.

With the current retry logic and the max retry, the total wait duration until timeout is 510 seconds.
```
irb(main):006:0> 8.times.inject(0) {|acc, x| acc + 1000 * (2 ** (x + 1))}                                                                                                                                       
=> 510000
```

So, this PR increases the max retry to 20 so that total wait duration (542 seconds) is similar to the original one
```
irb(main):017:0> 20.times.inject(0) {|acc, x| acc + [1000 * (2 ** (x + 1)), 32000].min}                                                                                                                         
=> 542000
```
(Actually if the max retry is 19, the total wait duration is 510 seconds as same as the original one. But 19 seems a bit weird to me, and I set it to 20. But I don't have a strong opinion on it.)

## Related issues and/or PRs

https://github.com/scalar-labs/scalar-jepsen/pull/97

## Changes made

- Introduced an upper limit for the retry in `scalardb` test
- Increased the max retry up to 20
- Updated the unit test

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None
