### PR TITLE
Exclude commons-lang3 lib from Cassandra dependency in ScalarDB and ScalarDL tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,6 +20,11 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
+    - name: Install leiningen
+      uses: DeLaGuardo/setup-clojure@13.0
+      with:
+        lein: latest
+
     - name: Cache m2 repository
       uses: actions/cache@v3
       with:

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -7,7 +7,7 @@
                  [net.java.dev.jna/jna "5.11.0"]
                  [net.java.dev.jna/jna-platform "5.11.0"]
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
-                 [cassandra "0.1.0-SNAPSHOT"]
+                 [cassandra "0.1.0-SNAPSHOT" :exclusions [org.apache.commons/commons-lang3]]
                  [cheshire "5.12.0"]
                  [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}

--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -21,7 +21,7 @@
                                                          io.grpc/grpc-core
                                                          com.scalar-labs/scalardb-rpc]]]}
              :use-jars {:dependencies [[com.google.guava/guava "31.1-jre"]
-                                       [org.apache.commons/commons-text "1.10.0"]]
+                                       [org.apache.commons/commons-text "1.13.0"]]
                         :resource-paths ["resources/scalardb.jar"]}
              :default [:base :system :user :provided :dev :use-released]}
   :jvm-opts ["-Djava.awt.headless=true"]

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -9,7 +9,7 @@
                  [net.java.dev.jna/jna "5.11.0"]
                  [net.java.dev.jna/jna-platform "5.11.0"]
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
-                 [cassandra "0.1.0-SNAPSHOT"]
+                 [cassandra "0.1.0-SNAPSHOT" :exclusions [org.apache.commons/commons-lang3]]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0"]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}


### PR DESCRIPTION
## Description

We are encountering the following errors while running the ScalarDB and ScalarDL tests:

ScalarDB:
```java
ERROR [2024-12-18 10:13:47,560] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
java.lang.NoClassDefFoundError: org/apache/commons/lang3/function/FailableSupplier
        at org.apache.commons.text.lookup.InetAddressStringLookup.<clinit>(InetAddressStringLookup.java:46)
        at org.apache.commons.text.lookup.StringLookupFactory.localHostStringLookup(StringLookupFactory.java:1130)
        at org.apache.commons.text.lookup.DefaultStringLookup.<clinit>(DefaultStringLookup.java:107)
        at org.apache.commons.text.lookup.StringLookupFactory$DefaultStringLookupsHolder.createDefaultStringLookups(StringLookupFactory.java:291)
        at org.apache.commons.text.lookup.StringLookupFactory$DefaultStringLookupsHolder.<init>(StringLookupFactory.java:344)
        at org.apache.commons.text.lookup.StringLookupFactory$DefaultStringLookupsHolder.<clinit>(StringLookupFactory.java:266)
        at org.apache.commons.text.lookup.StringLookupFactory.addDefaultStringLookups(StringLookupFactory.java:660)
        at org.apache.commons.text.lookup.InterpolatorStringLookup.<init>(InterpolatorStringLookup.java:70)
        at org.apache.commons.text.lookup.InterpolatorStringLookup.<init>(InterpolatorStringLookup.java:93)
        at org.apache.commons.text.lookup.InterpolatorStringLookup.<init>(InterpolatorStringLookup.java:84)
        at org.apache.commons.text.lookup.InterpolatorStringLookup.<init>(InterpolatorStringLookup.java:55)
        at org.apache.commons.text.lookup.InterpolatorStringLookup.<clinit>(InterpolatorStringLookup.java:37)
        at org.apache.commons.text.lookup.StringLookupFactory.interpolatorStringLookup(StringLookupFactory.java:1037)
        at com.scalar.db.config.ConfigUtils.<clinit>(ConfigUtils.java:33)
        at com.scalar.db.config.DatabaseConfig.load(DatabaseConfig.java:98)
        at com.scalar.db.config.DatabaseConfig.<init>(DatabaseConfig.java:80)
        at com.scalar.db.service.TransactionFactory.create(TransactionFactory.java:69)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:167)
        at clojure.lang.Reflector.invokeStaticMethod(Reflector.java:332)
        at scalardb.core$create_service_instance.invokeStatic(core.clj:153)
        at scalardb.core$create_service_instance.invoke(core.clj:145)
        at scalardb.core$prepare_service_BANG_.invokeStatic(core.clj:168)
        at scalardb.core$prepare_service_BANG_.invoke(core.clj:160)
        at scalardb.core$prepare_2pc_service_BANG_.invokeStatic(core.clj:189)
        at scalardb.core$prepare_2pc_service_BANG_.invoke(core.clj:187)
        at scalardb.transfer_2pc.TransferClient.setup_BANG_(transfer_2pc.clj:53)
        at jepsen.core$run_case_BANG_$fn__13416.invoke(core.clj:212)
        at dom_top.core$real_pmap_helper$build_thread__537$fn__538.invoke(core.clj:163)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1990)
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1990)
        at clojure.lang.RestFn.invoke(RestFn.java:425)
        at clojure.lang.AFn.applyToHelper(AFn.java:156)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.core$apply.invokeStatic(core.clj:671)
        at clojure.core$bound_fn_STAR_$fn__5818.doInvoke(core.clj:2020)
        at clojure.lang.RestFn.invoke(RestFn.java:397)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang3.function.FailableSupplier
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
        ... 45 common frames omitted
```

ScalarDL:
```java
ERROR [2024-12-17 10:51:05,747] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
java.lang.NoClassDefFoundError: Could not initialize class com.scalar.dl.ledger.config.ConfigUtils
        at com.scalar.dl.client.config.ClientConfig.load(ClientConfig.java:381)
        at com.scalar.dl.client.config.ClientConfig.<init>(ClientConfig.java:330)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at clojure.lang.Reflector.invokeConstructor(Reflector.java:305)
        at scalardl.core$prepare_client_service$fn__236.invoke(core.clj:64)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.core$apply.invoke(core.clj:662)
        at scalardl.core$retry_when_exception_STAR_$fn__228.invoke(core.clj:34)
        at scalardl.core$retry_when_exception_STAR_.invokeStatic(core.clj:34)
        at scalardl.core$retry_when_exception_STAR_.invoke(core.clj:31)
        at scalardl.core$retry_when_exception.invokeStatic(core.clj:51)
        at scalardl.core$retry_when_exception.invoke(core.clj:47)
        at scalardl.core$retry_when_exception.invokeStatic(core.clj:49)
        at scalardl.core$retry_when_exception.invoke(core.clj:47)
        at scalardl.core$prepare_client_service.invokeStatic(core.clj:63)
        at scalardl.core$prepare_client_service.invoke(core.clj:61)
        at scalardl.cas.CasRegisterClient.open_BANG_(cas.clj:59)
        at jepsen.core$run_case_BANG_$fn__13416.invoke(core.clj:212)
        at dom_top.core$real_pmap_helper$build_thread__537$fn__538.invoke(core.clj:163)
        at clojure.lang.AFn.applyToHelper(AFn.java:152)
        at clojure.lang.AFn.applyTo(AFn.java:144)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1990)
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1990)
        at clojure.lang.RestFn.invoke(RestFn.java:425)
        at clojure.lang.AFn.applyToHelper(AFn.java:156)
        at clojure.lang.RestFn.applyTo(RestFn.java:132)
        at clojure.core$apply.invokeStatic(core.clj:671)
        at clojure.core$bound_fn_STAR_$fn__5818.doInvoke(core.clj:2020)
        at clojure.lang.RestFn.invoke(RestFn.java:397)
        at clojure.lang.AFn.run(AFn.java:22)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

The root cause of both errors is a dependency conflict with the `commons-lang3` library. To address this issue, this PR excludes the library.

## Related issues and/or PRs

N/A

## Changes made

- Excluded the `commons-lang3` library from the Cassandra dependency in ScalarDB and ScalarDL tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
