### PR TITLE
Exclude commons-lang3 lib from hayt dependency in ScalarDL test

### DIFF
--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -11,7 +11,7 @@
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cassandra "0.1.0-SNAPSHOT" :exclusions [org.apache.commons/commons-lang3]]
                  [cc.qbits/alia "4.3.6"]
-                 [cc.qbits/hayt "4.1.0"]]
+                 [cc.qbits/hayt "4.1.0" :exclusions [org.apache.commons/commons-lang3]]]
   :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}


### PR DESCRIPTION
## Description

In addition to https://github.com/scalar-labs/scalar-jepsen/pull/134, we needed to exclude the `commons-lang3` lib from the `hayt` dependency in the ScalarDL test. This PR addresses it. 

## Related issues and/or PRs

- https://github.com/scalar-labs/scalar-jepsen/pull/134

## Changes made

- Excluded the `commons-lang3` lib from the `hayt` dependency in ScalarDL test.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
