### PR TITLE
Remove serializable strategy config

### DIFF
--- a/scalardb/src/scalardb/db_extend.clj
+++ b/scalardb/src/scalardb/db_extend.clj
@@ -12,9 +12,6 @@
 (def ^:private ISOLATION_LEVELS {:snapshot "SNAPSHOT"
                                  :serializable "SERIALIZABLE"})
 
-(def ^:private SERIALIZABLE_STRATEGIES {:extra-read "EXTRA_READ"
-                                        :extra-write "EXTRA_WRITE"})
-
 (defn- load-config
   [test]
   (when-let [path (and (seq (:config-file test)) (:config-file test))]
@@ -28,8 +25,6 @@
   (doto properties
     (.setProperty "scalar.db.consensus_commit.isolation_level"
                   ((:isolation-level test) ISOLATION_LEVELS))
-    (.setProperty "scalar.db.consensus_commit.serializable_strategy"
-                  ((:serializable-strategy test) SERIALIZABLE_STRATEGIES))
     (.setProperty "scalar.db.consensus_commit.coordinator.group_commit.enabled"
                   (str (:enable-group-commit test)))
     (.setProperty "scalar.db.consensus_commit.coordinator.group_commit.slot_capacity" "4")

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -113,13 +113,6 @@
     :validate [#{:snapshot :serializable}
                "Should be one of snapshot or serializable"]]
 
-   [nil "--serializable-strategy SERIALIZABLE_STRATEGY"
-    "serializable strategy"
-    :default :extra-read
-    :parse-fn keyword
-    :validate [#{:extra-read :extra-write}
-               "Should be one of extra-read or extra-write"]]
-
    (cli/repeated-opt nil "--consistency-model CONSISTENCY_MODEL"
                      "consistency model to be checked"
                      ["snapshot-isolation"])

--- a/scalardb/test/scalardb/db_extend_test.clj
+++ b/scalardb/test/scalardb/db_extend_test.clj
@@ -7,8 +7,7 @@
   (let [db (ext/extend-db (cassandra/db) :cassandra)
         properties (ext/create-properties db
                                           {:nodes ["n1" "n2" "n3"]
-                                           :isolation-level :serializable
-                                           :serializable-strategy :extra-write})]
+                                           :isolation-level :serializable})]
     (is (= "n1,n2,n3"
            (.getProperty properties "scalar.db.contact_points")))
     (is (= "cassandra"
@@ -18,8 +17,4 @@
     (is (= "SERIALIZABLE"
            (.getProperty
             properties
-            "scalar.db.consensus_commit.isolation_level")))
-    (is (= "EXTRA_WRITE"
-           (.getProperty
-            properties
-            "scalar.db.consensus_commit.serializable_strategy")))))
+            "scalar.db.consensus_commit.isolation_level")))))

--- a/scalardb/test/scalardb/elle_append_2pc_test.clj
+++ b/scalardb/test/scalardb/elle_append_2pc_test.clj
@@ -114,7 +114,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
@@ -144,7 +143,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
@@ -168,7 +166,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)
                                     :unknown-tx (atom #{})}
                                    {:type :invoke

--- a/scalardb/test/scalardb/elle_append_test.clj
+++ b/scalardb/test/scalardb/elle_append_test.clj
@@ -95,7 +95,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
@@ -120,7 +119,6 @@
                                nil nil)
           result (client/invoke! client
                                  {:isolation-level :serializable
-                                  :serializable-strategy :extra-write
                                   :table-id (atom 1)}
                                  {:type :invoke
                                   :f :txn
@@ -138,7 +136,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)
                                     :unknown-tx (atom #{})}
                                    {:type :invoke

--- a/scalardb/test/scalardb/elle_write_read_2pc_test.clj
+++ b/scalardb/test/scalardb/elle_write_read_2pc_test.clj
@@ -114,7 +114,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
@@ -143,7 +142,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
@@ -167,7 +165,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)
                                     :unknown-tx (atom #{})}
                                    {:type :invoke

--- a/scalardb/test/scalardb/elle_write_read_test.clj
+++ b/scalardb/test/scalardb/elle_write_read_test.clj
@@ -95,7 +95,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)}
                                    {:type :invoke
                                     :f :txn
@@ -119,7 +118,6 @@
                                nil nil)
           result (client/invoke! client
                                  {:isolation-level :serializable
-                                  :serializable-strategy :extra-write
                                   :table-id (atom 1)}
                                  {:type :invoke
                                   :f :txn
@@ -137,7 +135,6 @@
                                  nil nil)
             result (client/invoke! client
                                    {:isolation-level :serializable
-                                    :serializable-strategy :extra-write
                                     :table-id (atom 1)
                                     :unknown-tx (atom #{})}
                                    {:type :invoke


### PR DESCRIPTION
## Description

This PR removes the serializable strategy config, as it was removed in https://github.com/scalar-labs/scalardb/pull/2597.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2597

## Changes made

- Removed the serializable strategy config.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
