### PR TITLE
Fix to retry read-all/scan-all for all IDs

### DIFF
--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -125,19 +125,23 @@
         (scalar/try-reconnection! test scalar/prepare-transaction-service!)
         (assoc op :type :fail :error {:results results})))))
 
-(defn- read-record
-  "Read and update the specified record with a transaction"
-  [test id]
-  (let [tx (scalar/start-transaction test)
-        tx-result (.get tx (prepare-get id))
-        ;; Need Storage API to read the transaction metadata
-        result (.get @(:storage test) (prepare-get id))]
-    ;; Put the same balance to check conflicts with in-flight transactions
-    (->> (calc-new-balance tx-result 0)
-         (prepare-put id)
-         (.put tx))
-    (.commit tx)
-    result))
+(defn- read-all
+  "Read and update the all records with a transaction"
+  [test n]
+  (try
+    (let [tx (scalar/start-transaction test)
+          tx-results (map #(.get tx (prepare-get %)) (range n))
+          ;; Need Storage API to read the transaction metadata
+          results (mapv #(.get @(:storage test) (prepare-get %)) (range n))]
+      ;; Put the same balance to check conflicts with in-flight transactions
+      (mapv #(->> (calc-new-balance %2 0) (prepare-put %1) (.put tx))
+            (range n)
+            tx-results)
+      (.commit tx)
+      results)
+    (catch Exception e
+      (warn "read-all failed:" (.getMessage e))
+      nil)))
 
 (defn read-all-with-retry
   [test n]
@@ -148,12 +152,7 @@
       (scalar/prepare-transaction-service! test)
       (scalar/prepare-storage-service! test))
     test
-    (try
-      (mapv #(read-record test %) (range n))
-      (catch Exception e
-        ;; Read failure or the transaction conflicted
-        (warn (.getMessage e))
-        nil))))
+    (read-all test n)))
 
 (defrecord TransferClient [initialized? n initial-balance max-txs]
   client/Client

--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -139,25 +139,21 @@
     (.commit tx)
     result))
 
-(defn- read-record-with-retry
-  [test id]
+(defn read-all-with-retry
+  [test n]
+  (scalar/check-transaction-connection! test)
+  (scalar/check-storage-connection! test)
   (scalar/with-retry
     (fn [test]
       (scalar/prepare-transaction-service! test)
       (scalar/prepare-storage-service! test))
     test
     (try
-      (read-record test id)
+      (mapv #(read-record test %) (range n))
       (catch Exception e
         ;; Read failure or the transaction conflicted
         (warn (.getMessage e))
         nil))))
-
-(defn read-all-with-retry
-  [test n]
-  (scalar/check-transaction-connection! test)
-  (scalar/check-storage-connection! test)
-  (doall (map #(read-record-with-retry test %) (range n))))
 
 (defrecord TransferClient [initialized? n initial-balance max-txs]
   client/Client

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -127,18 +127,24 @@
         :fail))
     :start-fail))
 
-(defn- scan-records
-  "Scan records and append a new record with a transaction"
-  [test id]
-  (let [tx (scalar/start-transaction test)
-        results (.scan tx (prepare-scan id))]
-    ;; Put the same balance to check conflicts with in-flight transactions
-    (->> (prepare-put id
-                      (-> results first calc-new-age)
-                      (-> results first (calc-new-balance 0)))
-         (.put tx))
-    (.commit tx)
-    results))
+(defn- scan-all-records
+  "Scan all records and append new records with a transaction"
+  [test n]
+  (try
+    (let [tx (scalar/start-transaction test)
+          results (map #(.scan tx (prepare-scan %)) (range n))]
+      ;; Put the same balance to check conflicts with in-flight transactions
+      (mapv #(->> (prepare-put %1
+                               (-> %2 first calc-new-age)
+                               (-> %2 first (calc-new-balance 0)))
+                  (.put tx))
+            (range n)
+            results)
+      (.commit tx)
+      results)
+    (catch Exception e
+      (warn "scan-all failed:" (.getMessage e))
+      nil)))
 
 (defn scan-all-records-with-retry
   [test n]
@@ -146,12 +152,7 @@
   (scalar/with-retry
     scalar/prepare-transaction-service!
     test
-    (try
-      (mapv #(scan-records test %) (range n))
-      (catch Exception e
-        ;; Scan failure or the transaction conflicted
-        (warn (.getMessage e))
-        nil))))
+    (scan-all-records test n)))
 
 (defrecord TransferClient [initialized? n initial-balance max-txs]
   client/Client

--- a/scalardb/src/scalardb/transfer_append.clj
+++ b/scalardb/src/scalardb/transfer_append.clj
@@ -140,20 +140,18 @@
     (.commit tx)
     results))
 
-(defn- scan-records-with-retry
-  [test id]
-  (scalar/with-retry scalar/prepare-transaction-service! test
+(defn scan-all-records-with-retry
+  [test n]
+  (scalar/check-transaction-connection! test)
+  (scalar/with-retry
+    scalar/prepare-transaction-service!
+    test
     (try
-      (scan-records test id)
+      (mapv #(scan-records test %) (range n))
       (catch Exception e
         ;; Scan failure or the transaction conflicted
         (warn (.getMessage e))
         nil))))
-
-(defn scan-all-records-with-retry
-  [test n]
-  (scalar/check-transaction-connection! test)
-  (doall (map #(scan-records-with-retry test %) (range n))))
 
 (defrecord TransferClient [initialized? n initial-balance max-txs]
   client/Client


### PR DESCRIPTION
## Description
When read fails in the `get-all`, some results were used without retry.
It was caused by retrying the read/scan for each ID.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Retry `get-all` for all IDs with a single transaction

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
