### PR TITLE
Support READ-COMMITTED isolation

### DIFF
--- a/scalardb/src/scalardb/db_extend.clj
+++ b/scalardb/src/scalardb/db_extend.clj
@@ -23,7 +23,7 @@
   [test properties]
   (doto properties
     (.setProperty "scalar.db.consensus_commit.isolation_level"
-                  (-> test :isolation-level name string/upper-case))
+                  (-> test :isolation-level name string/upper-case (string/replace #"-" "_")))
     (.setProperty "scalar.db.consensus_commit.coordinator.group_commit.enabled"
                   (str (:enable-group-commit test)))
     (.setProperty "scalar.db.consensus_commit.coordinator.group_commit.slot_capacity" "4")

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -115,8 +115,8 @@
    [nil "--isolation-level ISOLATION_LEVEL" "isolation level"
     :default :snapshot
     :parse-fn keyword
-    :validate [#{:snapshot :serializable}
-               "Should be one of snapshot or serializable"]]
+    :validate [#{:read-committed :snapshot :serializable}
+               "Should be one of read-committed, snapshot, or serializable"]]
 
    (cli/repeated-opt nil "--consistency-model CONSISTENCY_MODEL"
                      "consistency model to be checked"


### PR DESCRIPTION
## Description

This PR adds support for the `READ-COMMITTED` isolation introduced by https://github.com/scalar-labs/scalardb/pull/2803.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2803

## Changes made

- Fixed the validation for the isolation level.
- Added a string conversion for the isolation level.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
