### PR TITLE
Support one-phase commit optimization

### DIFF
--- a/scalardb/src/scalardb/db_extend.clj
+++ b/scalardb/src/scalardb/db_extend.clj
@@ -24,6 +24,8 @@
   (doto properties
     (.setProperty "scalar.db.consensus_commit.isolation_level"
                   (-> test :isolation-level name string/upper-case))
+    (.setProperty "scalar.db.consensus_commit.one_phase_commit.enabled"
+                  (str (:enable-one-phase-commit test)))
     (.setProperty "scalar.db.consensus_commit.coordinator.group_commit.enabled"
                   (str (:enable-group-commit test)))
     (.setProperty "scalar.db.consensus_commit.coordinator.group_commit.slot_capacity" "4")

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -122,6 +122,9 @@
                      "consistency model to be checked"
                      ["snapshot-isolation"])
 
+   [nil "--enable-one-phase-commit" "if set, one-phase commit is enabled"
+    :default false]
+
    [nil "--enable-group-commit" "if set, group commit is enabled"
     :default false]
 


### PR DESCRIPTION
## Description

This PR adds support for one-phase commit optimization introduced by https://github.com/scalar-labs/scalardb/pull/2811.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb/pull/2811

## Changes made

- Added support for one-phase commit optimization.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
