### PR TITLE
Notify when a test fails

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -229,9 +229,15 @@ jobs:
             done < "$file"
           done
 
+          if [ -n "$failures" ]; then
+            icon=":fire:"
+          else
+            icon=":white_check_mark:"
+          fi
+
           {
             echo "message<<EOF"
-            printf ":white_check_mark: *ScalarDB Cluster tests completed*\n\n"
+            printf "${icon} *ScalarDB Cluster tests completed*\n\n"
             printf "*Success:*\n%s\n" "$successes"
             printf "*Failed:*\n%s\n" "$failures"
             printf "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>\n"


### PR DESCRIPTION
## Description
Currently, the Slack message always puts ✅ , but it could be misunderstood that all the tests passed.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Put :fire: to the slack message when at least one test failed

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
