### PR TITLE
Add options for ScalarDB test workflows

### DIFF
--- a/.github/workflows/cluster-test.yml
+++ b/.github/workflows/cluster-test.yml
@@ -35,6 +35,10 @@ on:
           - partition
           - packet
           - clock
+      enable_one_phase_commit:
+        description: 'Enable one phase commit'
+        default: false
+        type: boolean
       enable_group_commit:
         description: 'Enable Group commit'
         default: false
@@ -44,6 +48,7 @@ on:
         type: choice
         default: snapshot
         options:
+          - read-committed
           - snapshot
           - serializable
       consistency_model:
@@ -152,9 +157,14 @@ jobs:
         OPTS+=" --nemesis ${{ github.event.inputs.nemesis }}"
         OPTS+=" --isolation-level ${{ github.event.inputs.isolation_level }}"
         OPTS+=" --consistency-model ${{ github.event.inputs.consistency_model }}"
+
+        if [ "${{ github.event.inputs.enable_one_phase_commit }}" = "true" ]; then
+          OPTS+=" --enable-one-phase-commit"
+        fi
         if [ "${{ github.event.inputs.enable_group_commit }}" = "true" ]; then
           OPTS+=" --enable-group-commit"
         fi
+
         lein with-profile cluster run test \
           --nodes localhost \
           --db cluster \

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -85,7 +85,7 @@ jobs:
             enable_group_commit: false
             isolation_level: "snapshot"
             consistency_model: "cursor-stability"
-            time_limit: 180
+            time_limit: 600
           - name: "GroupCommit"
             workload: "elle-append elle-write-read"
             nemesis: "none partition packet clock crash"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,45 +17,83 @@ jobs:
           - name: "Transfers_SI"
             workload: "transfer transfer-append"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: false
             isolation_level: "snapshot"
             consistency_model: "snapshot-isolation"
+            time_limit: 600
           - name: "Transfers_2PC_SI"
             workload: "transfer-2pc transfer-append-2pc"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: false
             isolation_level: "snapshot"
             consistency_model: "snapshot-isolation"
+            time_limit: 600
+          - name: "ReadCommitted"
+            workload: "elle-append elle-write-read"
+            nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
+            enable_group_commit: false
+            isolation_level: "read-committed"
+            consistency_model: "cursor-stability"
+            time_limit: 600
+          - name: "ReadCommitted_2PC"
+            workload: "elle-append-2pc elle-write-read-2pc"
+            nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
+            enable_group_commit: false
+            isolation_level: "read-committed"
+            consistency_model: "cursor-stability"
+            time_limit: 600
           - name: "RCSI"
             workload: "elle-append elle-write-read"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: false
             isolation_level: "snapshot"
             consistency_model: "cursor-stability"
+            time_limit: 600
           - name: "RCSI_2PC"
             workload: "elle-append-2pc elle-write-read-2pc"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: false
             isolation_level: "snapshot"
             consistency_model: "cursor-stability"
+            time_limit: 600
           - name: "Serializable"
             workload: "elle-append elle-write-read"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: false
             isolation_level: "serializable"
             consistency_model: "strict-serializable"
+            time_limit: 600
           - name: "Serializable_2PC"
             workload: "elle-append-2pc elle-write-read-2pc"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: false
             isolation_level: "serializable"
             consistency_model: "strict-serializable"
+            time_limit: 600
+          - name: "OnePhaseCommit"
+            workload: "elle-append elle-write-read"
+            nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: true
+            enable_group_commit: false
+            isolation_level: "snapshot"
+            consistency_model: "cursor-stability"
+            time_limit: 180
           - name: "GroupCommit"
             workload: "elle-append elle-write-read"
             nemesis: "none partition packet clock crash"
+            enable_one_phase_commit: false
             enable_group_commit: true
             isolation_level: "serializable"
             consistency_model: "strict-serializable"
+            time_limit: 600
 
     steps:
     - uses: actions/checkout@v4
@@ -152,11 +190,14 @@ jobs:
         done
         OPTS+=" --isolation-level ${{ matrix.tests.isolation_level }}"
         OPTS+=" --consistency-model ${{ matrix.tests.consistency_model }}"
+        if [ "${{ matrix.tests.enable_one_phase_commit }}" = "true" ]; then
+          OPTS+=" --enable-one-phase-commit"
+        fi
         if [ "${{ matrix.tests.enable_group_commit }}" = "true" ]; then
           OPTS+=" --enable-group-commit"
         fi
         lein with-profile cluster run test \
-          --time-limit 600 \
+          --time-limit ${{ matrix.tests.time_limit }} \
           --nodes localhost \
           --db cluster \
           --concurrency 5 \

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -52,7 +52,11 @@
         new-db-props (-> values
                          (get-in path)
                          (str "\nscalar.db.consensus_commit.isolation_level="
-                              (-> test :isolation-level name str/upper-case)))]
+                              (-> test
+                                  :isolation-level
+                                  name
+                                  str/upper-case
+                                  (str/replace #"-" "_"))))]
     (assoc-in values path new-db-props)))
 
 (defn- install!


### PR DESCRIPTION
## Description
Add options to enable `READ_COMMITTED` and `one phase commit` to ScalarDB test workflows

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add `READ_COMMITTED` isolation level to the daily and the dispatched test
- Set `--enable-one-phase-commit` option for the daily and the dispatched test

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
