### PR TITLE
Update Maven snapshot repository

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -11,7 +11,7 @@
                  [clj-commons/clj-yaml "1.0.29"]
                  [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"]
                  [environ "1.2.0"]]
-  :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
+  :repositories {"sonartype" "https://central.sonatype.com/repository/maven-snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
              :use-released {:dependencies [[com.scalar-labs/scalardb "4.0.0-SNAPSHOT"

--- a/scalardl/project.clj
+++ b/scalardl/project.clj
@@ -12,7 +12,7 @@
                  [cassandra "0.1.0-SNAPSHOT" :exclusions [org.apache.commons/commons-lang3]]
                  [cc.qbits/alia "4.3.6"]
                  [cc.qbits/hayt "4.1.0" :exclusions [org.apache.commons/commons-lang3]]]
-  :repositories {"sonartype" "https://oss.sonatype.org/content/repositories/snapshots/"}
+  :repositories {"sonartype" "https://central.sonatype.com/repository/maven-snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
              :use-released {:dependencies [[com.scalar-labs/scalardl-java-client-sdk "4.0.0-SNAPSHOT"


### PR DESCRIPTION
## Description

Since we switched the snapshot repository used for uploading SNAPSHOT versions in ScalarDL (https://github.com/scalar-labs/scalardl/pull/194) and ScalarDB (https://github.com/scalar-labs/scalardb/pull/2849), we should also update the repository reference accordingly. This PR addresses that.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardl/pull/194
- https://github.com/scalar-labs/scalardb/pull/2849

## Changes made

- Updated the snapshot repository references.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have considered whether similar issues could occur in other products, components, or modules if this PR is for bug fixes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
