### PR TITLE
Add logging for transfer and transfer-append workloads

### DIFF
--- a/scalardb/src/scalardb/transfer.clj
+++ b/scalardb/src/scalardb/transfer.clj
@@ -1,6 +1,6 @@
 (ns scalardb.transfer
   (:require [clojure.core.reducers :as r]
-            [clojure.tools.logging :refer [info warn]]
+            [clojure.tools.logging :refer [infof warn]]
             [jepsen
              [client :as client]
              [checker :as checker]
@@ -86,12 +86,14 @@
 
 (defn- tx-transfer
   [tx from to amount]
-  (info "Transferring" amount "from" from "to" to "by tx" (.getId tx))
+  (infof "Transferring %d from %d to %d (tx: %s)" amount from to (.getId tx))
   (let [fromResult (.get tx (prepare-get from))
         toResult (.get tx (prepare-get to))]
+    (infof "fromID: %d, the balance: %d, the version: %d (tx: %s)" from (get-balance fromResult) (get-version fromResult) (.getId tx))
     (->> (calc-new-balance fromResult (- amount))
          (prepare-put from)
          (.put tx))
+    (infof "toID: %d, the balance: %d, the version: %d (tx: %s)" to (get-balance toResult) (get-version toResult) (.getId tx))
     (->> (calc-new-balance toResult amount)
          (prepare-put to)
          (.put tx))

--- a/scalardb/test/scalardb/transfer_append_test.clj
+++ b/scalardb/test/scalardb/transfer_append_test.clj
@@ -62,6 +62,7 @@
 (def mock-transaction
   (reify
     DistributedTransaction
+    (getId [_] "dummy-id")
     (^java.util.List scan [_ ^Scan s] (mock-scan s))
     (^void put [_ ^Put p] (mock-put p))
     (^void commit [_] (swap! commit-count inc))))
@@ -69,6 +70,7 @@
 (def mock-transaction-throws-exception
   (reify
     DistributedTransaction
+    (getId [_] "dummy-id")
     (^java.util.List scan [_ ^Scan _] (throw (CrudException. "scan failed" nil)))
     (^void put [_ ^Put _] (throw (CrudException. "put failed" nil)))
     (^void commit [_] (throw (CommitException. "commit failed" nil)))))


### PR DESCRIPTION
## Description

This PR adds logging for the `transfer` and `transfer-append` workloads to improve observability and debugging.

## Related issues and/or PRs

N/A

## Changes made

- Added logging for the `transfer` and `transfer-append` workloads.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
