### PR TITLE
Add exception handling for start-transaction in elle-write-read workload

### DIFF
--- a/scalardb/src/scalardb/elle_write_read.clj
+++ b/scalardb/src/scalardb/elle_write_read.clj
@@ -1,5 +1,5 @@
 (ns scalardb.elle-write-read
-  (:require [clojure.tools.logging :refer [info]]
+  (:require [clojure.tools.logging :refer [info warn]]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.independent :as independent]
@@ -92,7 +92,9 @@
         (scalar/prepare-transaction-service! test))))
 
   (invoke! [_ test op]
-    (let [tx (scalar/start-transaction test)
+    (let [tx (try (scalar/start-transaction test)
+                  (catch Exception e
+                    (warn (.getMessage e))))
           [seq-id txn] (:value op)]
       (try
         (when (<= @(:table-id test) seq-id)


### PR DESCRIPTION
## Description

This PR adds exception handling for `start-transaction` in the `elle-write-read` workload to handle errors that may occur when starting transactions. Similar exception handling has already been implemented in other workloads.

## Related issues and/or PRs

N/A

## Changes made

- Added exception handling for start in the `elle-write-read` workload.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
