### PR TITLE
Use Bitnami legacy images

### DIFF
--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -109,14 +109,20 @@
 
 (defn- start!
   [test]
-  ;; postgre
+  ;; postgresql
   (c/exec
    :helm :install "postgresql-scalardb-cluster" "bitnami/postgresql"
    :--set "auth.postgresPassword=postgres"
    :--set "primary.persistence.enabled=true"
    ;; Need an external IP for storage APIs
    :--set "service.type=LoadBalancer"
-   :--set "primary.service.type=LoadBalancer")
+   :--set "primary.service.type=LoadBalancer"
+   ;; Use legacy images
+   :--set "image.repository=bitnamilegacy/postgresql"
+   :--set "volumePermissions.image.repository=bitnamilegacy/os-shell"
+   :--set "metrics.image.repository=bitnamilegacy/postgres-exporter"
+   :--set "global.security.allowInsecureImages=true"
+   :--version "16.7.0")
 
   ;; ScalarDB Cluster
   (let [chart-version (or (some-> (env :helm-chart-version) not-empty)


### PR DESCRIPTION
## Description

This PR updates the ScalarDB Cluster tests to use the Bitnami legacy images due to changes in the Bitnami catalog:  
https://github.com/bitnami/charts/issues/35164

This is a temporary workaround, and we should eventually switch to using the Bitnami Secure Images.

## Related issues and/or PRs

N/A

## Changes made

- Updated the ScalarDB Cluster tests to use the Bitnami legacy.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
