### PR TITLE
Fix Netty dependency conflict

### DIFF
--- a/scalardb/project.clj
+++ b/scalardb/project.clj
@@ -9,9 +9,9 @@
                  [org.slf4j/slf4j-jdk14 "2.0.6"]
                  [cheshire "5.12.0"]
                  [clj-commons/clj-yaml "1.0.29"]
-                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT"]
+                 [com.scalar-labs/scalardb-schema-loader "4.0.0-SNAPSHOT" :exclusions [com.scalar-labs/scalardb]]
                  [environ "1.2.0"]]
-  :repositories {"sonartype" "https://central.sonatype.com/repository/maven-snapshots/"}
+  :repositories {"sonatype" "https://central.sonatype.com/repository/maven-snapshots/"}
   :profiles {:dev {:dependencies [[tortue/spy "2.0.0"]]
                    :plugins [[lein-cloverage "1.1.2"]]}
              :use-released {:dependencies [[com.scalar-labs/scalardb "4.0.0-SNAPSHOT"
@@ -19,17 +19,22 @@
                                             :exclusions [software.amazon.awssdk/*
                                                          com.oracle.database.jdbc/ojdbc8-production
                                                          com.azure/azure-cosmos
-                                                         io.grpc/grpc-core
-                                                         com.scalar-labs/scalardb-rpc]]]}
+                                                         io.grpc/grpc-core]]]}
              :cassandra {:dependencies [[cassandra "0.1.0-SNAPSHOT"
-                                         :exclusions [org.apache.commons/commons-lang3]]]
+                                         :exclusions [org.apache.commons/commons-lang3]]
+                                        [com.scalar-labs/scalardb "4.0.0-SNAPSHOT"
+                                         ;; avoid the netty dependency issue
+                                         :exclusions [software.amazon.awssdk/*
+                                                      com.oracle.database.jdbc/ojdbc8-production
+                                                      com.azure/azure-cosmos
+                                                      io.grpc/grpc-core]]]
                          :env {:cassandra? "true"}}
              :cluster {:dependencies [[com.scalar-labs/scalardb-cluster-java-client-sdk "4.0.0-SNAPSHOT"
                                        ;; avoid the netty dependency issue
                                        :exclusions [software.amazon.awssdk/*
                                                     com.oracle.database.jdbc/ojdbc8-production
                                                     com.azure/azure-cosmos
-                                                    com.scalar-labs/scalardb-rpc]]]
+                                                    com.datastax.cassandra/cassandra-driver-core]]]
                        :env {:scalardb-cluster-version "4.0.0-SNAPSHOT"
                              :helm-chart-version "1.7.2"}}
              :use-jars {:dependencies [[com.google.guava/guava "31.1-jre"]


### PR DESCRIPTION
## Description

After upgrading the gRPC library from `1.74.0` to `1.75.0` in https://github.com/scalar-labs/scalardb-cluster/pull/1245, we started encountering the following errors in the ScalarDB Cluster Jepsen tests:

<details>
  <summary>
    Exception1
  </summary>

```java
2025-09-20 13:40:57,264{GMT}    WARN    [clojure-agent-send-off-pool-23] scalardb.transfer: Starting a transaction failed
com.scalar.db.exception.transaction.TransactionException: INTERNAL: http2 exception. Transaction ID: 8984e611-49f0-484d-bc56-bbb084029472
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:132)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:97)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.lambda$begin$0(ClusterClientTransactionManager.java:102)
        at com.scalar.db.cluster.client.AuthTokenManager.executeWithAuthToken(AuthTokenManager.java:37)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:93)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:73)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:68)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:39)
        at com.scalar.db.api.DistributedTransactionManager.start(DistributedTransactionManager.java:123)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.start(ClusterClientTransactionManager.java:124)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:167)
        at clojure.lang.Reflector.invokeNoArgInstanceMember(Reflector.java:438)
        at scalardb.core$start_transaction.invokeStatic(core.clj:151)
        at scalardb.core$start_transaction.invoke(core.clj:149)
        at scalardb.transfer$try_tx_transfer$fn__1446.invoke(transfer.clj:107)
        at scalardb.transfer$try_tx_transfer.invokeStatic(transfer.clj:107)
        at scalardb.transfer$try_tx_transfer.invoke(transfer.clj:105)
        at scalardb.transfer$exec_transfers$fn__1456.invoke(transfer.clj:126)
        at clojure.core$pmap$fn__8552$fn__8553.invoke(core.clj:7089)
        at clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)
        at clojure.lang.AFn.call(AFn.java:18)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusRuntimeException: INTERNAL: http2 exception
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:368)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:349)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:174)
        at com.scalar.db.cluster.rpc.v1.DistributedTransactionGrpc$DistributedTransactionBlockingStub.begin(DistributedTransactionGrpc.java:1086)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:141)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:110)
        ... 28 common frames omitted
Caused by: io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception: Frame length: 3289700 exceeds maximum: 16384
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception.connectionError(Http2Exception.java:107)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader.preProcessFrame(DefaultHttp2FrameReader.java:187)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:146)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:39)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:391)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:451)
        at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
        at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
        at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
        at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
        at io.grpc.netty.shaded.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799)
        at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501)
        at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399)
        at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
        at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        ... 1 common frames omitted
```

</details>

<details>
  <summary>
    Exception2
  </summary>

```java
2025-09-20 13:40:57,951{GMT}    WARN    [clojure-agent-send-off-pool-17] scalardb.transfer: Starting a transaction failed
com.scalar.db.exception.transaction.TransactionException: INTERNAL: Encountered end-of-stream mid-frame. Transaction ID: 29bb16f0-3b3d-478b-9bbc-e7a01b5c3916
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:132)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:97)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.lambda$begin$0(ClusterClientTransactionManager.java:102)
        at com.scalar.db.cluster.client.AuthTokenManager.executeWithAuthToken(AuthTokenManager.java:37)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:93)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:73)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:68)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.begin(ClusterClientTransactionManager.java:39)
        at com.scalar.db.api.DistributedTransactionManager.start(DistributedTransactionManager.java:123)
        at com.scalar.db.cluster.client.ClusterClientTransactionManager.start(ClusterClientTransactionManager.java:124)
        at jdk.internal.reflect.GeneratedMethodAccessor7.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:167)
        at clojure.lang.Reflector.invokeNoArgInstanceMember(Reflector.java:438)
        at scalardb.core$start_transaction.invokeStatic(core.clj:151)
        at scalardb.core$start_transaction.invoke(core.clj:149)
        at scalardb.transfer$try_tx_transfer$fn__1446.invoke(transfer.clj:107)
        at scalardb.transfer$try_tx_transfer.invokeStatic(transfer.clj:107)
        at scalardb.transfer$try_tx_transfer.invoke(transfer.clj:105)
        at scalardb.transfer$exec_transfers$fn__1456.invoke(transfer.clj:126)
        at clojure.core$pmap$fn__8552$fn__8553.invoke(core.clj:7089)
        at clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)
        at clojure.lang.AFn.call(AFn.java:18)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusRuntimeException: INTERNAL: Encountered end-of-stream mid-frame
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:368)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:349)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:174)
        at com.scalar.db.cluster.rpc.v1.DistributedTransactionGrpc$DistributedTransactionBlockingStub.begin(DistributedTransactionGrpc.java:1086)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:141)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.begin(RemoteDistributedTransactionService.java:110)
        ... 27 common frames omitted
```

</details>

<details>
  <summary>
    Exception3
  </summary>

```java
2025-09-20 13:40:58,301{GMT}    WARN    [clojure-agent-send-off-pool-33] scalardb.transfer: An error occurred during the transaction
com.scalar.db.exception.transaction.CrudException: INTERNAL: http2 exception. Transaction ID: 73c612a7-bddc-42f8-8f19-623f6ad2a24c
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.executeCrud(RemoteDistributedTransactionService.java:564)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.get(RemoteDistributedTransactionService.java:155)
        at com.scalar.db.cluster.client.ClusterClientTransaction.lambda$get$0(ClusterClientTransaction.java:67)
        at com.scalar.db.cluster.client.ClusterClientTransaction.lambda$executeCrud$13(ClusterClientTransaction.java:202)
        at com.scalar.db.cluster.client.AuthTokenManager.executeWithAuthToken(AuthTokenManager.java:37)
        at com.scalar.db.cluster.client.ClusterClientTransaction.executeCrud(ClusterClientTransaction.java:200)
        at com.scalar.db.cluster.client.ClusterClientTransaction.get(ClusterClientTransaction.java:66)
        at jdk.internal.reflect.GeneratedMethodAccessor14.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:167)
        at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:102)
        at scalardb.transfer$tx_transfer.invokeStatic(transfer.clj:90)
        at scalardb.transfer$tx_transfer.invoke(transfer.clj:87)
        at scalardb.transfer$try_tx_transfer.invokeStatic(transfer.clj:111)
        at scalardb.transfer$try_tx_transfer.invoke(transfer.clj:105)
        at scalardb.transfer$exec_transfers$fn__1456.invoke(transfer.clj:126)
        at clojure.core$pmap$fn__8552$fn__8553.invoke(core.clj:7089)
        at clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)
        at clojure.lang.AFn.call(AFn.java:18)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusRuntimeException: INTERNAL: http2 exception
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:368)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:349)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:174)
        at com.scalar.db.cluster.rpc.v1.DistributedTransactionGrpc$DistributedTransactionBlockingStub.get(DistributedTransactionGrpc.java:1096)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.get(RemoteDistributedTransactionService.java:174)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.lambda$get$0(RemoteDistributedTransactionService.java:164)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.executeCrud(RemoteDistributedTransactionService.java:531)
        ... 23 common frames omitted
Caused by: io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception: Error decoding headers: decode only works with an entire header block! UnpooledSlicedByteBuf(ridx: 5, widx: 11, cap: 11/11, unwrapped: CompositeByteBuf(ridx: 20, widx: 336, cap: 336, components=1))
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2Exception.connectionError(Http2Exception.java:121)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder.decodeHeaders(DefaultHttp2HeadersDecoder.java:168)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader$HeadersBlockBuilder.headers(DefaultHttp2FrameReader.java:737)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:475)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:483)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:247)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:164)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:39)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:391)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:451)
        at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:530)
        at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:469)
        at io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
        at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1357)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
        at io.grpc.netty.shaded.io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
        at io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:868)
        at io.grpc.netty.shaded.io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:799)
        at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:501)
        at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:399)
        at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
        at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        ... 1 common frames omitted
Caused by: java.lang.IllegalArgumentException: decode only works with an entire header block! UnpooledSlicedByteBuf(ridx: 5, widx: 11, cap: 11/11, unwrapped: CompositeByteBuf(ridx: 20, widx: 336, cap: 336, components=1))
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.HpackDecoder.notEnoughDataException(HpackDecoder.java:460)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.HpackDecoder.decode(HpackDecoder.java:299)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.HpackDecoder.decode(HpackDecoder.java:132)
        at io.grpc.netty.shaded.io.netty.handler.codec.http2.DefaultHttp2HeadersDecoder.decodeHeaders(DefaultHttp2HeadersDecoder.java:158)
        ... 26 common frames omitted
```

</details>

<details>
  <summary>
    Exception4
  </summary>

```java
2025-09-20 13:41:00,645{GMT}    WARN    [clojure-agent-send-off-pool-21] scalardb.transfer: An error occurred during the transaction
com.scalar.db.exception.transaction.CrudException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 110493957. Transaction ID: da928b3a-bf17-467d-9974-b7f2d2d48a3a
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.executeCrud(RemoteDistributedTransactionService.java:564)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.get(RemoteDistributedTransactionService.java:155)
        at com.scalar.db.cluster.client.ClusterClientTransaction.lambda$get$0(ClusterClientTransaction.java:67)
        at com.scalar.db.cluster.client.ClusterClientTransaction.lambda$executeCrud$13(ClusterClientTransaction.java:202)
        at com.scalar.db.cluster.client.AuthTokenManager.executeWithAuthToken(AuthTokenManager.java:37)
        at com.scalar.db.cluster.client.ClusterClientTransaction.executeCrud(ClusterClientTransaction.java:200)
        at com.scalar.db.cluster.client.ClusterClientTransaction.get(ClusterClientTransaction.java:66)
        at jdk.internal.reflect.GeneratedMethodAccessor14.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:167)
        at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:102)
        at scalardb.transfer$tx_transfer.invokeStatic(transfer.clj:93)
        at scalardb.transfer$tx_transfer.invoke(transfer.clj:87)
        at scalardb.transfer$try_tx_transfer.invokeStatic(transfer.clj:111)
        at scalardb.transfer$try_tx_transfer.invoke(transfer.clj:105)
        at scalardb.transfer$exec_transfers$fn__1456.invoke(transfer.clj:126)
        at clojure.core$pmap$fn__8552$fn__8553.invoke(core.clj:7089)
        at clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)
        at clojure.lang.AFn.call(AFn.java:18)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 110493957
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:368)
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:349)
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:174)
        at com.scalar.db.cluster.rpc.v1.DistributedTransactionGrpc$DistributedTransactionBlockingStub.get(DistributedTransactionGrpc.java:1096)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.get(RemoteDistributedTransactionService.java:174)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.lambda$get$0(RemoteDistributedTransactionService.java:164)
        at com.scalar.db.cluster.common.RemoteDistributedTransactionService.executeCrud(RemoteDistributedTransactionService.java:531)
        ... 23 common frames omitted
```

</details>


It seems that the issue was caused by Netty dependency conflicts. To address this, this PR removes the Netty dependency from the ScalarDB Cluster Jepsen tests.

I tested this fix, and the errors no longer occur.

## Related issues and/or PRs

N/A

## Changes made

- Removed unnecessary Netty dependencies.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
