### PR TITLE
Fix nemesis for network failures

### DIFF
--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -146,6 +146,8 @@
                   :-n "chaos-mesh"
                   :-p "{\"metadata\":{\"finalizers\":[]}}"
                   :--type "merge"
+                  ;; Need the deletion command with the pipe
+                  ;; because the finalizers could be reverted
                   c/|
                   :kubectl :delete "networkchaos" action :-n "chaos-mesh"))
         (.delete file)))))

--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -145,7 +145,9 @@
           (c/exec :kubectl :patch "networkchaos" action
                   :-n "chaos-mesh"
                   :-p "{\"metadata\":{\"finalizers\":[]}}"
-                  :--type "merge"))
+                  :--type "merge"
+                  c/|
+                  :kubectl :delete "networkchaos" action :-n "chaos-mesh"))
         (.delete file)))))
 
 (defn delete-partition-exp

--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -146,9 +146,9 @@
                   :-n "chaos-mesh"
                   :-p "{\"metadata\":{\"finalizers\":[]}}"
                   :--type "merge"
-                  ;; Need the deletion command with the pipe
+                  ;; Need the deletion command immediately
                   ;; because the finalizers could be reverted
-                  c/|
+                  c/&&
                   :kubectl :delete "networkchaos" action :-n "chaos-mesh"))
         (.delete file)))))
 

--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -146,9 +146,8 @@
                   :-n "chaos-mesh"
                   :-p "{\"metadata\":{\"finalizers\":[]}}"
                   :--type "merge"
-                  ;; Need the deletion command immediately
-                  ;; because the finalizers could be reverted
-                  c/&&
+                  ;; Hack: Need the pipe to avoid reverting the finalizers before deletion
+                  c/|
                   :kubectl :delete "networkchaos" action :-n "chaos-mesh"))
         (.delete file)))))
 


### PR DESCRIPTION
## Description
Some nemesis for network failures failed to start because the existing ChaosMesh experiment wasn't deleted.
We need to delete the existing one.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Delete the experiment

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
