### PR TITLE
Use Java 11 for Cassandra nodes in ScalarDL test

### DIFF
--- a/scalardl/src/scalardl/core.clj
+++ b/scalardl/src/scalardl/core.clj
@@ -110,17 +110,18 @@
           :> LEDGER_PROPERTIES))
 
 (defn- install-jdk-with-retry
-  []
-  (retry-when-exception (fn [package]
-                          (c/su (debian/install package)))
-                        [[:openjdk-21-jre]]
-                        debian/update!))
+  [server?]
+  (let [jre (if server? :openjdk-21-jre :openjdk-11-jre)]
+    (retry-when-exception (fn [package]
+                            (c/su (debian/install package)))
+                          [[jre]]
+                          debian/update!)))
 
 (defn- install-server!
   [node test]
   (info node "installing DL server")
   (c/su (c/exec :rm :-rf LEDGER_INSTALL_DIR))
-  (install-jdk-with-retry)
+  (install-jdk-with-retry (util/server? node test))
   (c/upload (:ledger-tarball test) "/tmp/ledger.tar")
   (cu/install-archive! "file:///tmp/ledger.tar" LEDGER_INSTALL_DIR)
   (c/upload (:server-key test) LEDGER_KEY)


### PR DESCRIPTION
## Description
Cassandra cluster didn't start in ScalarDL test with Java 21, but Java 21 is required by the latest ScalarDL.
(We shouldn't use Cassandra 3.11 anymore because it is already EOL...)

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Use Java 11 on Cassandra nodes

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
