### PR TITLE
Daily ScalarDL test with Docker

### DIFF
--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -76,8 +76,6 @@ jobs:
       with:
         path: docker-cache
         key: ${{ runner.os }}-docker-jepsen-${{ hashFiles('docker/**/Dockerfile', 'docker/**/init.sh') }}
-        restore-keys: |
-          ${{ runner.os }}-docker-jepsen-
 
     - name: Restore Docker images from cache
       run: |

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -33,13 +33,13 @@ jobs:
         path: scalardl-build
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -49,7 +49,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Cache m2 repository
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: m2-cache
         key: ${{ runner.os }}-m2-dl-${{ hashFiles('**/project.clj') }}
@@ -64,7 +64,7 @@ jobs:
         cp ledger/build/distributions/ledger.tar $GITHUB_WORKSPACE/scalardl/resources/ledger.tar
 
     - name: Set up Docker
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Cache Docker layers
       uses: satackey/action-docker-layer-caching@v0.0.11

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - daily-dl-test
-
 jobs:
   daily-dl:
     name: "DL-${{ matrix.tests.name }}"
@@ -66,14 +65,31 @@ jobs:
     - name: Set up Docker
       uses: docker/setup-buildx-action@v4
 
-    - name: Cache Docker layers
-      uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
+    - name: Cache Docker images
+      uses: actions/cache@v4
+      with:
+        path: docker-cache
+        key: ${{ runner.os }}-docker-jepsen-${{ hashFiles('docker/**/Dockerfile', 'docker/**/init.sh') }}
+        restore-keys: |
+          ${{ runner.os }}-docker-jepsen-
+
+    - name: Restore Docker images from cache
+      run: |
+        if [ -f docker-cache/images.tar ]; then
+          docker load -i docker-cache/images.tar
+        fi
 
     - name: Start Jepsen Docker environment
       run: |
         cd docker
         docker compose up -d
+
+    - name: Save Docker images to cache
+      run: |
+        if [ ! -f docker-cache/images.tar ]; then
+          mkdir -p docker-cache
+          docker save $(docker compose -f docker/docker-compose.yaml images -q | sort -u) -o docker-cache/images.tar
+        fi
 
     - name: Wait for containers to be ready
       run: |

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -1,9 +1,9 @@
 name: Daily ScalarDL test
 
 on:
-  push:
-    branches:
-      - daily-dl-test
+  schedule:
+    - cron: "0 15 * * *"
+
 jobs:
   daily-dl:
     name: "DL-${{ matrix.tests.name }}"
@@ -15,11 +15,17 @@ jobs:
       matrix:
         tests:
           - name: "nemesis-none"
+            workload: "all"
             nemesis: "none"
+            time_limit: 600
           - name: "nemesis-crash"
+            workload: "all"
             nemesis: "crash"
+            time_limit: 600
           - name: "nemesis-partition"
+            workload: "all"
             nemesis: "partition"
+            time_limit: 600
 
     steps:
     - name: Checkout scalar-jepsen
@@ -118,10 +124,10 @@ jobs:
         docker exec jepsen-control bash -c "\
           cd /scalar-jepsen/scalardl && \
           lein run test \
-            --workload all \
+            --workload ${{ matrix.tests.workload }} \
             --nemesis ${{ matrix.tests.nemesis }} \
             --concurrency 5 \
-            --time-limit 60 \
+            --time-limit ${{ matrix.tests.time_limit }} \
             --ssh-private-key ~/.ssh/id_rsa"
 
     - name: Save m2 cache from container

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -23,22 +23,22 @@ jobs:
 
     steps:
     - name: Checkout scalar-jepsen
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Checkout ScalarDL
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: scalar-labs/scalardl
         path: scalardl-build
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches
@@ -48,7 +48,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Cache m2 repository
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: m2-cache
         key: ${{ runner.os }}-m2-dl-${{ hashFiles('**/project.clj') }}
@@ -66,7 +66,7 @@ jobs:
       uses: docker/setup-buildx-action@v4
 
     - name: Cache Docker images
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: docker-cache
         key: ${{ runner.os }}-docker-jepsen-${{ hashFiles('docker/**/Dockerfile', 'docker/**/init.sh') }}
@@ -141,7 +141,7 @@ jobs:
 
     - name: Upload result
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: result-${{ matrix.tests.name }}
         path: result-${{ matrix.tests.name }}.txt
@@ -153,7 +153,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: logs-${{ matrix.tests.name }}
         path: store-${{ matrix.tests.name }}

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -1,7 +1,9 @@
 name: Daily ScalarDL test
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - daily-dl-test
 
 jobs:
   daily-dl:
@@ -75,7 +77,7 @@ jobs:
             --workload all \
             --nemesis ${{ matrix.tests.nemesis }} \
             --concurrency 5 \
-            --time-limit 600 \
+            --time-limit 60 \
             --ssh-private-key ~/.ssh/id_rsa"
 
     - name: Record result

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -68,9 +68,6 @@ jobs:
         # Copy the built tarball to the expected location
         cp ledger/build/distributions/ledger.tar $GITHUB_WORKSPACE/scalardl/resources/ledger.tar
 
-    - name: Set up Docker
-      uses: docker/setup-buildx-action@v4
-
     - name: Cache Docker images
       uses: actions/cache@v5
       with:

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -1,0 +1,168 @@
+name: Daily ScalarDL test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  daily-dl:
+    name: "DL-${{ matrix.tests.name }}"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          - name: "nemesis-none"
+            nemesis: "none"
+          - name: "nemesis-crash"
+            nemesis: "crash"
+          - name: "nemesis-partition"
+            nemesis: "partition"
+
+    steps:
+    - name: Checkout scalar-jepsen
+      uses: actions/checkout@v4
+
+    - name: Checkout ScalarDL
+      uses: actions/checkout@v4
+      with:
+        repository: scalar-labs/scalardl
+        path: scalardl-build
+
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Build ScalarDL
+      run: |
+        cd scalardl-build
+        ./gradlew distTar
+        # Copy the built tarball to the expected location
+        cp server/build/distributions/server-*.tar $GITHUB_WORKSPACE/scalardl/resources/ledger.tar
+
+    - name: Set up Docker
+      uses: docker/setup-buildx-action@v3
+
+    - name: Start Jepsen Docker environment
+      run: |
+        cd docker
+        docker compose up -d
+
+    - name: Wait for containers to be ready
+      run: |
+        # Wait for all containers to be running
+        for node in jepsen-control jepsen-n1 jepsen-n2 jepsen-n3 jepsen-n4 jepsen-n5; do
+          echo "Waiting for $node..."
+          until docker inspect -f '{{.State.Running}}' $node 2>/dev/null | grep -q true; do
+            sleep 1
+          done
+        done
+        # Give SSH a moment to start
+        sleep 5
+
+    - name: Install Cassandra test tool
+      run: |
+        docker exec jepsen-control bash -c "cd /scalar-jepsen/cassandra && lein install"
+
+    - name: Run ScalarDL Jepsen test (${{ matrix.tests.nemesis }})
+      run: |
+        docker exec jepsen-control bash -c "\
+          cd /scalar-jepsen/scalardl && \
+          lein run test \
+            --workload all \
+            --nemesis ${{ matrix.tests.nemesis }} \
+            --concurrency 5 \
+            --time-limit 600 \
+            --ssh-private-key ~/.ssh/id_rsa"
+
+    - name: Record result
+      if: always()
+      run: |
+        if docker exec jepsen-control bash -c "grep -q 'Everything looks good!' /scalar-jepsen/scalardl/store/latest/jepsen.log"; then
+          echo "${{ matrix.tests.name }}:success" > result-${{ matrix.tests.name }}.txt
+        else
+          echo "${{ matrix.tests.name }}:failure" > result-${{ matrix.tests.name }}.txt
+        fi
+
+    - name: Upload result
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: result-${{ matrix.tests.name }}
+        path: result-${{ matrix.tests.name }}.txt
+
+    - name: Copy logs from container
+      if: always()
+      run: |
+        docker cp jepsen-control:/scalar-jepsen/scalardl/store store-${{ matrix.tests.name }} || true
+
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.tests.name }}
+        path: store-${{ matrix.tests.name }}
+
+  notify-slack:
+    name: Notify Slack
+    if: always()
+    needs: daily-dl
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Download result artifacts only
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          mkdir -p results
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --jq '.artifacts[] | select(.name | startswith("result-")) | .name' | \
+            while read name; do
+              echo "Downloading $name"
+              gh run download ${{ github.run_id }} -n "$name" -D results -R "${{ github.repository }}"
+            done
+
+      - name: Generate Slack message
+        id: message
+        run: |
+          successes=""
+          failures=""
+
+          for file in results/result-*.txt; do
+            while read -r line; do
+              name=$(echo "$line" | cut -d: -f1)
+              status=$(echo "$line" | cut -d: -f2)
+
+              if [ "$status" = "success" ]; then
+                successes="${successes}- $name\n"
+              else
+                failures="${failures}- $name\n"
+              fi
+            done < "$file"
+          done
+
+          if [ -n "$failures" ]; then
+            icon=":fire:"
+          else
+            icon=":white_check_mark:"
+          fi
+
+          {
+            echo "message<<EOF"
+            printf "${icon} *ScalarDL tests completed*\n\n"
+            printf "*Success:*\n%s\n" "$successes"
+            printf "*Failed:*\n%s\n" "$failures"
+            printf "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>\n"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Post to Slack
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"${{ steps.message.outputs.message }}\"}" \
+            ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -43,7 +43,7 @@ jobs:
         cd scalardl-build
         ./gradlew distTar
         # Copy the built tarball to the expected location
-        cp server/build/distributions/server-*.tar $GITHUB_WORKSPACE/scalardl/resources/ledger.tar
+        cp ledger/build/distributions/ledger.tar $GITHUB_WORKSPACE/scalardl/resources/ledger.tar
 
     - name: Set up Docker
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/dl-test.yaml
+++ b/.github/workflows/dl-test.yaml
@@ -38,6 +38,24 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
 
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('scalardl-build/**/*.gradle*', 'scalardl-build/**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Cache m2 repository
+      uses: actions/cache@v3
+      with:
+        path: m2-cache
+        key: ${{ runner.os }}-m2-dl-${{ hashFiles('**/project.clj') }}
+        restore-keys: |
+          ${{ runner.os }}-m2-dl-
+
     - name: Build ScalarDL
       run: |
         cd scalardl-build
@@ -47,6 +65,10 @@ jobs:
 
     - name: Set up Docker
       uses: docker/setup-buildx-action@v3
+
+    - name: Cache Docker layers
+      uses: satackey/action-docker-layer-caching@v0.0.11
+      continue-on-error: true
 
     - name: Start Jepsen Docker environment
       run: |
@@ -65,6 +87,12 @@ jobs:
         # Give SSH a moment to start
         sleep 5
 
+    - name: Restore m2 cache to container
+      run: |
+        if [ -d m2-cache ] && [ "$(ls -A m2-cache)" ]; then
+          docker cp m2-cache/. jepsen-control:/root/.m2/
+        fi
+
     - name: Install Cassandra test tool
       run: |
         docker exec jepsen-control bash -c "cd /scalar-jepsen/cassandra && lein install"
@@ -79,6 +107,12 @@ jobs:
             --concurrency 5 \
             --time-limit 60 \
             --ssh-private-key ~/.ssh/id_rsa"
+
+    - name: Save m2 cache from container
+      if: always()
+      run: |
+        rm -rf m2-cache
+        docker cp jepsen-control:/root/.m2 m2-cache || true
 
     - name: Record result
       if: always()


### PR DESCRIPTION
## Description
As an alternative daily test, add a new workflow for the daily ScalarDL test with Docker
`clock` nemesis is excluded because the failure can't be injected into the Docker environment.

NOTE: This testing is a trial for now. Currently, we have an issue with the environment (Ubuntu version). The daily ScalarDL tests have not worked for a few weeks. We are continuing to investigate the issue, but have not resolved it yet. We could replace the existing daily test with this one.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add `dl-test.yaml` workflow to set up the Docker environment, run the test, then report the results

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
