### PR TITLE
fix the timeout check

### DIFF
--- a/.github/workflows/daily-cluster.yml
+++ b/.github/workflows/daily-cluster.yml
@@ -426,6 +426,7 @@ jobs:
         if [ "${{ matrix.tests.enable_client_side_optimizations }}" = "true" ]; then
           OPTS+=" --enable-cluster-client-side-optimizations"
         fi
+        set +e
         DOCKER_USERNAME=${{ github.repository_owner }} \
         DOCKER_ACCESS_TOKEN=${{ secrets.CR_PAT }} \
         lein with-profile cluster run test \
@@ -436,7 +437,9 @@ jobs:
           --username runner \
           --ssh-private-key ~/.ssh/id_rsa \
           ${OPTS} > /dev/null 2>&1
+        EXIT_CODE=$?
         echo "done=true" >> $GITHUB_OUTPUT
+        exit $EXIT_CODE
 
     - name: Record result
       if: always()

--- a/.github/workflows/daily-cluster.yml
+++ b/.github/workflows/daily-cluster.yml
@@ -436,13 +436,14 @@ jobs:
           --username runner \
           --ssh-private-key ~/.ssh/id_rsa \
           ${OPTS} > /dev/null 2>&1
+        echo "done=true" >> $GITHUB_OUTPUT
 
     - name: Record result
       if: always()
       run: |
-        if [ "${{ steps.run-test.outcome }}" = "cancelled" ]; then
+        if [ "${{ steps.run-test.outputs.done }}" != "true" ]; then
           echo "${{ matrix.tests.name }}:timeout" > result-${{ matrix.tests.name }}.txt
-        elif grep -q "Everything looks good!" scalardb/store/latest/jepsen.log; then
+        elif [ "${{ steps.run-test.outcome }}" = "success" ]; then
           echo "${{ matrix.tests.name }}:success" > result-${{ matrix.tests.name }}.txt
         else
           echo "${{ matrix.tests.name }}:failure" > result-${{ matrix.tests.name }}.txt

--- a/.github/workflows/daily-db.yml
+++ b/.github/workflows/daily-db.yml
@@ -193,6 +193,7 @@ jobs:
           OPTS+=" --enable-cluster-client-side-optimizations"
         fi
 
+        set +e
         docker exec jepsen-control bash -c "\
           cd /scalar-jepsen/scalardb && \
           lein with-profile cassandra run test \
@@ -200,7 +201,9 @@ jobs:
             --concurrency 5 \
             --time-limit ${{ matrix.tests.time_limit }} \
             --ssh-private-key ~/.ssh/id_rsa"
+        EXIT_CODE=$?
         echo "done=true" >> $GITHUB_OUTPUT
+        exit $EXIT_CODE
 
     - name: Save m2 cache from container
       if: always()

--- a/.github/workflows/daily-db.yml
+++ b/.github/workflows/daily-db.yml
@@ -200,6 +200,7 @@ jobs:
             --concurrency 5 \
             --time-limit ${{ matrix.tests.time_limit }} \
             --ssh-private-key ~/.ssh/id_rsa"
+        echo "done=true" >> $GITHUB_OUTPUT
 
     - name: Save m2 cache from container
       if: always()
@@ -210,9 +211,9 @@ jobs:
     - name: Record result
       if: always()
       run: |
-        if [ "${{ steps.run-test.outcome }}" = "cancelled" ]; then
+        if [ "${{ steps.run-test.outputs.done }}" != "true" ]; then
           echo "${{ matrix.tests.name }}:timeout" > result-${{ matrix.tests.name }}.txt
-        elif docker exec jepsen-control bash -c "grep -q 'Everything looks good!' /scalar-jepsen/scalardb/store/latest/jepsen.log"; then
+        elif [ "${{ steps.run-test.outcome }}" = "success" ]; then
           echo "${{ matrix.tests.name }}:success" > result-${{ matrix.tests.name }}.txt
         else
           echo "${{ matrix.tests.name }}:failure" > result-${{ matrix.tests.name }}.txt

--- a/.github/workflows/daily-dl.yml
+++ b/.github/workflows/daily-dl.yml
@@ -126,6 +126,7 @@ jobs:
             --concurrency 5 \
             --time-limit ${{ matrix.tests.time_limit }} \
             --ssh-private-key ~/.ssh/id_rsa"
+        echo "done=true" >> $GITHUB_OUTPUT
 
     - name: Save m2 cache from container
       if: always()
@@ -136,9 +137,9 @@ jobs:
     - name: Record result
       if: always()
       run: |
-        if [ "${{ steps.run-test.outcome }}" = "cancelled" ]; then
+        if [ "${{ steps.run-test.outputs.done }}" != "true" ]; then
           echo "${{ matrix.tests.name }}:timeout" > result-${{ matrix.tests.name }}.txt
-        elif docker exec jepsen-control bash -c "grep -q 'Everything looks good!' /scalar-jepsen/scalardl/store/latest/jepsen.log"; then
+        elif [ "${{ steps.run-test.outcome }}" = "success" ]; then
           echo "${{ matrix.tests.name }}:success" > result-${{ matrix.tests.name }}.txt
         else
           echo "${{ matrix.tests.name }}:failure" > result-${{ matrix.tests.name }}.txt

--- a/.github/workflows/daily-dl.yml
+++ b/.github/workflows/daily-dl.yml
@@ -118,6 +118,7 @@ jobs:
       id: run-test
       timeout-minutes: 180
       run: |
+        set +e
         docker exec jepsen-control bash -c "\
           cd /scalar-jepsen/scalardl && \
           lein run test \
@@ -126,7 +127,9 @@ jobs:
             --concurrency 5 \
             --time-limit ${{ matrix.tests.time_limit }} \
             --ssh-private-key ~/.ssh/id_rsa"
+        EXIT_CODE=$?
         echo "done=true" >> $GITHUB_OUTPUT
+        exit $EXIT_CODE
 
     - name: Save m2 cache from container
       if: always()


### PR DESCRIPTION
## Description
Still reporting wrong results for timed-out tests.
The `step.run-test.outcome` was not set to `canceled` when the step timed out.
Fix this issue by setting `step.run-test.outputs`.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- If `step.run-test.outputs.done` is empty, report "timeout"
- Don't check the `latest` directory

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
