### PR TITLE
Triage for daily tests

### DIFF
--- a/.github/scripts/triage.py
+++ b/.github/scripts/triage.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError
 
 TAIL_LINES = 200
 MAX_LINE_LEN = 2000
-ERROR_SNIPPET_LIMIT = 120
+ERROR_SNIPPET_LIMIT = 50
 
 ERROR_PATTERNS = re.compile(
     r"(ERROR|Exception|timeout|timed out|refused|reset|broken pipe|ssh|failed|failure|crash)",

--- a/.github/scripts/triage.py
+++ b/.github/scripts/triage.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+TAIL_LINES = 200
+MAX_LINE_LEN = 2000
+
+ERROR_PATTERNS = re.compile(
+    r"(ERROR|Exception|timeout|timed out|refused|reset|broken pipe|ssh|failed|failure|crash)",
+    re.IGNORECASE,
+)
+
+ANALYSIS_INVALID_PAT = re.compile(r"analysis invalid", re.IGNORECASE)
+ANALYSIS_ERRORS_NO_ANOMALIES_PAT = re.compile(
+    r"errors occurred during analysis.*no anomalies found", re.IGNORECASE
+)
+
+MODELS_API_URL = "https://models.github.ai/inference/chat/completions"
+MODEL_ID = "openai/gpt-4.1-mini"
+
+
+def load_lines(path: Path) -> list[str]:
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        return [line.rstrip("\n") for line in f]
+
+
+def shorten(line: str, max_len: int = MAX_LINE_LEN) -> str:
+    return line[:max_len]
+
+
+def last_nonempty_line(lines: list[str]) -> str:
+    for line in reversed(lines):
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+def extract_tail(lines: list[str], n: int = TAIL_LINES) -> list[str]:
+    return [shorten(x) for x in lines[-n:]]
+
+
+def extract_error_snippets(lines: list[str], limit: int = 120) -> list[str]:
+    out = []
+    for line in lines:
+        if ERROR_PATTERNS.search(line):
+            out.append(shorten(line))
+    return out[-limit:]
+
+
+def categorize_final_line(final_line: str) -> str:
+    if ANALYSIS_INVALID_PAT.search(final_line):
+        return "ANALYSIS_INVALID"
+    if ANALYSIS_ERRORS_NO_ANOMALIES_PAT.search(final_line):
+        return "ANALYSIS_ERRORS_NO_ANOMALIES"
+    return "OTHER_FAILURE"
+
+
+def parse_json_content(content: str) -> dict:
+    text = content.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*\n?", "", text)
+        text = re.sub(r"\n?```\s*$", "", text)
+    return json.loads(text)
+
+
+def call_github_models(
+    final_line: str,
+    category: str,
+    tail_lines: list[str],
+    error_lines: list[str],
+) -> dict:
+    token = os.environ["GITHUB_TOKEN"]
+
+    user_prompt = f"""
+You are analyzing a failed Jepsen test.
+
+The test did NOT succeed.
+
+The final status line is:
+
+{final_line}
+
+This final status line has been categorized as: {category}
+
+Category meanings:
+- ANALYSIS_INVALID: "Analysis invalid!" — the checker/analyzer reported the run
+  as invalid, but this does NOT by itself prove a real consistency bug.
+- ANALYSIS_ERRORS_NO_ANOMALIES: "Errors occurred during analysis, but no
+  anomalies found." — suggests analysis issues or infrastructure problems
+  without confirmed anomalies.
+- OTHER_FAILURE: anything else; typically an infrastructure or runtime error
+  before analysis could finish.
+
+These signals must be interpreted together with the logs.
+
+Your task:
+Classify this failure into exactly one of:
+
+- TEMPORARY_ISSUE
+  (likely transient, environmental, or infrastructure-related)
+
+- INCONSISTENCY_REQUIRES_INVESTIGATION
+  (credible evidence of a real consistency or correctness violation)
+
+- UNKNOWN_REQUIRES_HUMAN
+  (insufficient or conflicting evidence; needs manual inspection)
+
+Be conservative:
+- Only choose INCONSISTENCY_REQUIRES_INVESTIGATION if there is clear evidence
+  of a real anomaly (e.g., inconsistency, stale read, lost update, contradiction).
+- "Analysis invalid!" alone is NOT sufficient evidence.
+- Prefer UNKNOWN_REQUIRES_HUMAN over making a weak or speculative conclusion.
+- Choose TEMPORARY_ISSUE only if the failure is well-explained by
+  transient or environmental issues.
+
+Return strict JSON only with this schema:
+
+{{
+  "label": "TEMPORARY_ISSUE" | "INCONSISTENCY_REQUIRES_INVESTIGATION" | "UNKNOWN_REQUIRES_HUMAN",
+  "confidence": 0.0,
+  "reasoning": "short explanation",
+  "evidence": ["key observation", "..."]
+}}
+
+---
+
+FINAL_LINE:
+{final_line}
+
+---
+
+TAIL_LOG (last {TAIL_LINES} lines):
+{chr(10).join(tail_lines)}
+
+---
+
+ERROR_SNIPPETS:
+{chr(10).join(error_lines)}
+""".strip()
+
+    body = {
+        "model": MODEL_ID,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a careful CI failure triage assistant. Output JSON only."
+            },
+            {
+                "role": "user",
+                "content": user_prompt
+            }
+        ],
+        "temperature": 0.1,
+        "response_format": {"type": "json_object"},
+    }
+
+    req = Request(
+        MODELS_API_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urlopen(req) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub Models API error: {e.code} {detail}") from e
+
+    content = payload["choices"][0]["message"]["content"]
+    return parse_json_content(content)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--log", required=True)
+    ap.add_argument("--summary", required=True)
+    args = ap.parse_args()
+
+    log_path = Path(args.log)
+    summary_path = Path(args.summary)
+
+    lines = load_lines(log_path)
+    final_line = last_nonempty_line(lines)
+    category = categorize_final_line(final_line)
+
+    tail = extract_tail(lines, TAIL_LINES)
+    errors = extract_error_snippets(lines)
+    result = call_github_models(final_line, category, tail, errors)
+
+    md = []
+    md.append("## Jepsen triage")
+    md.append("")
+    md.append(f"- label: **{result['label']}**")
+    md.append(f"- confidence: **{result['confidence']}**")
+    md.append("")
+    md.append("### reasoning")
+    md.append(result["reasoning"])
+    md.append("")
+    md.append("### evidence")
+    for e in result["evidence"]:
+        md.append(f"- {e}")
+    md.append("")
+    md.append("### final line")
+    md.append("```")
+    md.append(final_line)
+    md.append("```")
+
+    summary_path.write_text("\n".join(md), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"triage failed: {e}", file=sys.stderr)
+        raise

--- a/.github/scripts/triage.py
+++ b/.github/scripts/triage.py
@@ -14,7 +14,7 @@ MAX_LINE_LEN = 2000
 ERROR_SNIPPET_LIMIT = 50
 
 ERROR_PATTERNS = re.compile(
-    r"(ERROR|Exception|timeout|timed out|refused|reset|broken pipe|ssh|failed|failure|crash)",
+    r"(ERROR|Exception|WARN|timeout|timed out|refused|reset|broken pipe|ssh|failed|failure|crash)",
     re.IGNORECASE,
 )
 

--- a/.github/scripts/triage.py
+++ b/.github/scripts/triage.py
@@ -22,7 +22,7 @@ ANALYSIS_ERRORS_NO_ANOMALIES_PAT = re.compile(
 )
 
 MODELS_API_URL = "https://models.github.ai/inference/chat/completions"
-MODEL_ID = "openai/gpt-4.1-mini"
+MODEL_ID = "openai/gpt-4o-mini"
 
 
 def load_lines(path: Path) -> list[str]:

--- a/.github/scripts/triage.py
+++ b/.github/scripts/triage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import collections
 import json
 import os
 import re
@@ -10,6 +11,7 @@ from urllib.error import HTTPError
 
 TAIL_LINES = 200
 MAX_LINE_LEN = 2000
+ERROR_SNIPPET_LIMIT = 120
 
 ERROR_PATTERNS = re.compile(
     r"(ERROR|Exception|timeout|timed out|refused|reset|broken pipe|ssh|failed|failure|crash)",
@@ -25,32 +27,26 @@ MODELS_API_URL = "https://models.github.ai/inference/chat/completions"
 MODEL_ID = "openai/gpt-4o-mini"
 
 
-def load_lines(path: Path) -> list[str]:
-    with path.open("r", encoding="utf-8", errors="replace") as f:
-        return [line.rstrip("\n") for line in f]
-
-
 def shorten(line: str, max_len: int = MAX_LINE_LEN) -> str:
     return line[:max_len]
 
 
-def last_nonempty_line(lines: list[str]) -> str:
-    for line in reversed(lines):
-        if line.strip():
-            return line.strip()
-    return ""
+def scan_log(path: Path) -> tuple[list[str], list[str], str]:
+    tail: collections.deque[str] = collections.deque(maxlen=TAIL_LINES)
+    errors: collections.deque[str] = collections.deque(maxlen=ERROR_SNIPPET_LIMIT)
+    last_nonempty = ""
 
+    with path.open("r", encoding="utf-8", errors="replace") as f:
+        for raw in f:
+            line = raw.rstrip("\n")
+            tail.append(shorten(line))
+            if ERROR_PATTERNS.search(line):
+                errors.append(shorten(line))
+            stripped = line.strip()
+            if stripped:
+                last_nonempty = stripped
 
-def extract_tail(lines: list[str], n: int = TAIL_LINES) -> list[str]:
-    return [shorten(x) for x in lines[-n:]]
-
-
-def extract_error_snippets(lines: list[str], limit: int = 120) -> list[str]:
-    out = []
-    for line in lines:
-        if ERROR_PATTERNS.search(line):
-            out.append(shorten(line))
-    return out[-limit:]
+    return list(tail), list(errors), last_nonempty
 
 
 def categorize_final_line(final_line: str) -> str:
@@ -192,12 +188,8 @@ def main():
     log_path = Path(args.log)
     summary_path = Path(args.summary)
 
-    lines = load_lines(log_path)
-    final_line = last_nonempty_line(lines)
+    tail, errors, final_line = scan_log(log_path)
     category = categorize_final_line(final_line)
-
-    tail = extract_tail(lines, TAIL_LINES)
-    errors = extract_error_snippets(lines)
     result = call_github_models(final_line, category, tail, errors)
 
     md = []

--- a/.github/scripts/triage.py
+++ b/.github/scripts/triage.py
@@ -24,7 +24,7 @@ ANALYSIS_ERRORS_NO_ANOMALIES_PAT = re.compile(
 )
 
 MODELS_API_URL = "https://models.github.ai/inference/chat/completions"
-MODEL_ID = "openai/gpt-4o-mini"
+MODEL_ID = "openai/gpt-4o-mini" # https://docs.github.com/en/billing/reference/costs-for-github-modelso
 
 
 def shorten(line: str, max_len: int = MAX_LINE_LEN) -> str:

--- a/.github/workflows/daily-cluster.yml
+++ b/.github/workflows/daily-cluster.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      models: read
+
     strategy:
       fail-fast: false
       matrix:
@@ -458,6 +462,35 @@ jobs:
       with:
         name: result-${{ matrix.tests.name }}
         path: result-${{ matrix.tests.name }}.txt
+
+    - name: First-pass triage with GitHub Models
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        LOG=scalardb/store/current/jepsen.log
+        if [ ! -f "$LOG" ]; then
+          echo "No jepsen.log found at $LOG; skipping triage"
+          exit 0
+        fi
+        mkdir -p triage-${{ matrix.tests.name }}
+        python3 .github/scripts/triage.py \
+          --log "$LOG" \
+          --summary triage-${{ matrix.tests.name }}/triage.md
+
+    - name: Append triage summary
+      if: failure()
+      run: |
+        if [ -f triage-${{ matrix.tests.name }}/triage.md ]; then
+          cat triage-${{ matrix.tests.name }}/triage.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Upload triage
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: triage-${{ matrix.tests.name }}
+        path: triage-${{ matrix.tests.name }}/triage.md
 
     - name: Upload logs
       if: always()

--- a/.github/workflows/daily-cluster.yml
+++ b/.github/workflows/daily-cluster.yml
@@ -477,6 +477,7 @@ jobs:
         python3 .github/scripts/triage.py \
           --log "$LOG" \
           --summary triage-${{ matrix.tests.name }}/triage.md
+      continue-on-error: true
 
     - name: Append triage summary
       if: failure()
@@ -491,6 +492,7 @@ jobs:
       with:
         name: triage-${{ matrix.tests.name }}
         path: triage-${{ matrix.tests.name }}/triage.md
+      continue-on-error: true
 
     - name: Upload logs
       if: always()

--- a/.github/workflows/daily-db.yml
+++ b/.github/workflows/daily-db.yml
@@ -252,6 +252,7 @@ jobs:
         python3 .github/scripts/triage.py \
           --log "$LOG" \
           --summary triage-${{ matrix.tests.name }}/triage.md
+      continue-on-error: true
 
     - name: Append triage summary
       if: failure()
@@ -266,6 +267,7 @@ jobs:
       with:
         name: triage-${{ matrix.tests.name }}
         path: triage-${{ matrix.tests.name }}/triage.md
+      continue-on-error: true
 
     - name: Upload logs
       if: always()

--- a/.github/workflows/daily-db.yml
+++ b/.github/workflows/daily-db.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      models: read
+
     strategy:
       fail-fast: false
       matrix:
@@ -233,6 +237,35 @@ jobs:
       if: always()
       run: |
         docker cp jepsen-control:/scalar-jepsen/scalardb/store store-${{ matrix.tests.name }} || true
+
+    - name: First-pass triage with GitHub Models
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        LOG=store-${{ matrix.tests.name }}/current/jepsen.log
+        if [ ! -f "$LOG" ]; then
+          echo "No jepsen.log found at $LOG; skipping triage"
+          exit 0
+        fi
+        mkdir -p triage-${{ matrix.tests.name }}
+        python3 .github/scripts/triage.py \
+          --log "$LOG" \
+          --summary triage-${{ matrix.tests.name }}/triage.md
+
+    - name: Append triage summary
+      if: failure()
+      run: |
+        if [ -f triage-${{ matrix.tests.name }}/triage.md ]; then
+          cat triage-${{ matrix.tests.name }}/triage.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Upload triage
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: triage-${{ matrix.tests.name }}
+        path: triage-${{ matrix.tests.name }}/triage.md
 
     - name: Upload logs
       if: always()

--- a/.github/workflows/daily-dl.yml
+++ b/.github/workflows/daily-dl.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      models: read
+
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +163,35 @@ jobs:
       if: always()
       run: |
         docker cp jepsen-control:/scalar-jepsen/scalardl/store store-${{ matrix.tests.name }} || true
+
+    - name: First-pass triage with GitHub Models
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        LOG=store-${{ matrix.tests.name }}/current/jepsen.log
+        if [ ! -f "$LOG" ]; then
+          echo "No jepsen.log found at $LOG; skipping triage"
+          exit 0
+        fi
+        mkdir -p triage-${{ matrix.tests.name }}
+        python3 .github/scripts/triage.py \
+          --log "$LOG" \
+          --summary triage-${{ matrix.tests.name }}/triage.md
+
+    - name: Append triage summary
+      if: failure()
+      run: |
+        if [ -f triage-${{ matrix.tests.name }}/triage.md ]; then
+          cat triage-${{ matrix.tests.name }}/triage.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    - name: Upload triage
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: triage-${{ matrix.tests.name }}
+        path: triage-${{ matrix.tests.name }}/triage.md
 
     - name: Upload logs
       if: always()

--- a/.github/workflows/daily-dl.yml
+++ b/.github/workflows/daily-dl.yml
@@ -178,6 +178,7 @@ jobs:
         python3 .github/scripts/triage.py \
           --log "$LOG" \
           --summary triage-${{ matrix.tests.name }}/triage.md
+      continue-on-error: true
 
     - name: Append triage summary
       if: failure()
@@ -192,6 +193,7 @@ jobs:
       with:
         name: triage-${{ matrix.tests.name }}
         path: triage-${{ matrix.tests.name }}/triage.md
+      continue-on-error: true
 
     - name: Upload logs
       if: always()


### PR DESCRIPTION
## Description
I'd like GitHub Models to triage the failure tests as the first analysis.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add triage.py to extract lines and call GitHub Models
- Modify workflows to call triage.py

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
