### PR TITLE
Fix network nemesis deletion

### DIFF
--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -142,7 +142,7 @@
 (defn- network-fault-exists?
   [name]
   (try
-    (c/exec :kubectl :get :networkchaos name :-n "chaos-mesh" :-o "name")
+    (c/exec :kubectl :get :networkchaos name :-n "chaos-mesh" :-o "name" :--request-timeout "10s")
     true
     (catch Exception _ false)))
 

--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -154,8 +154,8 @@
         (try
           (c/exec :kubectl :patch :networkchaos name
                   :-n "chaos-mesh"
-                  :--type "json"
-                  :-p "[{\"op\":\"remove\",\"path\":\"/metadata/finalizers\"}]"
+                  :--type "merge"
+                  :-p "{\"metadata\":{\"finalizers\":[]}}"
                   :--request-timeout "10s")
           (catch Exception e
             (warn "networkchaos finalizer patch failed (ignored)"

--- a/scalardb/src/scalardb/nemesis/cluster.clj
+++ b/scalardb/src/scalardb/nemesis/cluster.clj
@@ -1,7 +1,7 @@
 (ns scalardb.nemesis.cluster
   (:require [clj-yaml.core :as yaml]
             [clojure.string :as str]
-            [clojure.tools.logging :refer [error info]]
+            [clojure.tools.logging :refer [error info warn]]
             [jepsen
              [control :as c]
              [generator :as gen]
@@ -10,6 +10,9 @@
             [jepsen.nemesis.combined :as jn]
             [jepsen.nemesis.time :as nt])
   (:import (java.io File)))
+
+(def ^:private ^:const MAX_RETRIES 5)
+(def ^:private ^:const SLEEP_MS 1000)
 
 (def ^:private ^:const POD_FAULT_YAML "./pod-fault.yaml")
 (def ^:private ^:const PARTITION_YAML "./partition.yaml")
@@ -136,20 +139,68 @@
   [pod-names]
   (mapv #(-> % time-fault-yaml delete-chaos-exp) pod-names))
 
+(defn- network-fault-exists?
+  [name]
+  (try
+    (c/exec :kubectl :get :networkchaos name :-n "chaos-mesh" :-o "name")
+    true
+    (catch Exception _ false)))
+
+(defn- try-force-delete-network-fault
+  [name]
+  (loop [i 0]
+    (when (< i MAX_RETRIES)
+      (when (network-fault-exists? name)
+        (try
+          (c/exec :kubectl :patch :networkchaos name
+                  :-n "chaos-mesh"
+                  :--type "json"
+                  :-p "[{\"op\":\"remove\",\"path\":\"/metadata/finalizers\"}]"
+                  :--request-timeout "10s")
+          (catch Exception e
+            (warn "networkchaos finalizer patch failed (ignored)"
+                  {:name name :retry i :error (.getMessage e)})))
+
+        (try
+          (c/exec :kubectl :delete :networkchaos name
+                  :-n "chaos-mesh"
+                  :--wait=false
+                  :--ignore-not-found=true
+                  :--request-timeout "10s")
+          (catch Exception e
+            (warn "networkchaos delete retry failed (ignored)"
+                  {:name name :retry i :error (.getMessage e)})))
+
+        (Thread/sleep SLEEP_MS)
+
+        (recur (inc i))))))
+
 (defn- force-delete-network-fault-exp
   [yaml-path]
   (binding [c/*dir* (System/getProperty "user.dir")]
     (let [file (File. yaml-path)]
       (when (.exists file)
-        (let [action (-> yaml-path slurp yaml/parse-string :spec :action)]
-          (c/exec :kubectl :patch "networkchaos" action
-                  :-n "chaos-mesh"
-                  :-p "{\"metadata\":{\"finalizers\":[]}}"
-                  :--type "merge"
-                  ;; Hack: Need the pipe to avoid reverting the finalizers before deletion
-                  c/|
-                  :kubectl :delete "networkchaos" action :-n "chaos-mesh"))
-        (.delete file)))))
+        (let [name (-> yaml-path slurp yaml/parse-string :metadata :name)]
+          (try
+            (c/exec :kubectl :delete :networkchaos name
+                    :-n "chaos-mesh"
+                    :--wait=false
+                    :--ignore-not-found=true
+                    :--request-timeout "10s")
+            (catch Exception e
+              (warn "networkchaos delete failed (ignored)"
+                    {:name name :error (.getMessage e)})))
+
+          ;; if the network chaos still exists,
+          ;; try to force delete it by removing finalizers for several times
+          (try-force-delete-network-fault name)
+
+          (when (network-fault-exists? name)
+            (warn "networkchaos still exists after best-effort cleanup"
+                  {:name name :yaml yaml-path}))
+
+          (when-not (.delete file)
+            (warn "failed to delete local chaos yaml file" {:yaml yaml-path})))))))
 
 (defn delete-partition-exp
   []


### PR DESCRIPTION
## Description
We're facing a timeout issue.
I suspect that some network nemesis (partition/packet) got stuck when deleting(stopping) the experiment.
I'd like to fix it to get more robust and to ignore the deletion failure to avoid the stuck if needed.
This ignorance will not affect the Jepsen consistency checking.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Check the chaos mesh experiment is left
- Retry deleting the finalizers of the experiment
- Ignore the deletion failure if some retries don't work

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
