### PR TITLE
Support managed DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docker/keys/
 */.clj-kondo
 */.lein-*
 */.lsp
+managed.yaml

--- a/scalardb/managed.yaml.sample
+++ b/scalardb/managed.yaml.sample
@@ -1,0 +1,18 @@
+# Sample managed DB connection config.
+# Copy this file to managed.yaml (gitignored), fill in your details, and pass
+# it with --db managed --managed-db-config managed.yaml.
+
+# --- Option A: build the JDBC URL from parts ---
+# 'subprotocol' picks the JDBC driver. 'port' and 'database' are optional;
+# defaults are provided for postgresql (5432, "postgres") and mysql (3306, "jepsen").
+subprotocol: postgresql
+host: your-cluster.cluster-xxxxxxxx.us-east-1.rds.amazonaws.com
+# port: 5432
+# database: postgres
+
+# --- Option B: provide the full JDBC URL (overrides Option A) ---
+# Use this when you need SSL or other JDBC parameters.
+# jdbc-url: jdbc:postgresql://your-cluster.cluster-xxxxxxxx.us-east-1.rds.amazonaws.com:5432/postgres?ssl=true&sslmode=require
+
+username: postgres
+password: changeme

--- a/scalardb/managed.yaml.sample
+++ b/scalardb/managed.yaml.sample
@@ -39,3 +39,11 @@ password: changeme
 # contact-points: https://your-account.documents.azure.com:443/   # Cosmos DB URI
 # password: your-cosmos-primary-key                                # Cosmos DB key
 # username is not required for cosmos
+
+# ============================================================
+# Example D: External Cassandra cluster
+# ============================================================
+# storage: cassandra
+# contact-points: cass-node-1,cass-node-2,cass-node-3   # comma-separated host(s)
+# username: cassandra
+# password: cassandra

--- a/scalardb/managed.yaml.sample
+++ b/scalardb/managed.yaml.sample
@@ -1,18 +1,41 @@
 # Sample managed DB connection config.
 # Copy this file to managed.yaml (gitignored), fill in your details, and pass
 # it with --db managed --managed-db-config managed.yaml.
+#
+# Pick ONE of the storage blocks below and delete the others.
 
-# --- Option A: build the JDBC URL from parts ---
-# 'subprotocol' picks the JDBC driver. 'port' and 'database' are optional;
-# defaults are provided for postgresql (5432, "postgres") and mysql (3306, "jepsen").
+# ============================================================
+# Example A: JDBC (Aurora Postgres / MySQL, Cloud SQL, etc.)
+# ============================================================
+storage: jdbc
+
+# Option A1: build the JDBC URL from parts.
+# port and database default per subprotocol (postgresql: 5432/postgres,
+# mysql: 3306/jepsen).
 subprotocol: postgresql
 host: your-cluster.cluster-xxxxxxxx.us-east-1.rds.amazonaws.com
 # port: 5432
 # database: postgres
 
-# --- Option B: provide the full JDBC URL (overrides Option A) ---
+# Option A2: provide the full JDBC URL (overrides A1).
 # Use this when you need SSL or other JDBC parameters.
-# jdbc-url: jdbc:postgresql://your-cluster.cluster-xxxxxxxx.us-east-1.rds.amazonaws.com:5432/postgres?ssl=true&sslmode=require
+# contact-points: jdbc:postgresql://your-cluster.cluster-xxxxxxxx.us-east-1.rds.amazonaws.com:5432/postgres?ssl=true&sslmode=require
 
 username: postgres
 password: changeme
+
+# ============================================================
+# Example B: Amazon DynamoDB
+# ============================================================
+# storage: dynamo
+# contact-points: us-east-1                # AWS region
+# username: AKIAxxxxxxxxxxxxxxxx           # AWS_ACCESS_KEY_ID
+# password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # AWS_SECRET_ACCESS_KEY
+
+# ============================================================
+# Example C: Azure Cosmos DB for NoSQL
+# ============================================================
+# storage: cosmos
+# contact-points: https://your-account.documents.azure.com:443/   # Cosmos DB URI
+# password: your-cosmos-primary-key                                # Cosmos DB key
+# username is not required for cosmos

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -339,18 +339,26 @@
    :tidb      'scalardb.db.cluster-db.tidb/gen-cluster-db
    :sqlserver 'scalardb.db.cluster-db.sqlserver/gen-cluster-db
    :oracle    'scalardb.db.cluster-db.oracle/gen-cluster-db
-   :db2       'scalardb.db.cluster-db.db2/gen-cluster-db})
+   :db2       'scalardb.db.cluster-db.db2/gen-cluster-db
+   :managed   'scalardb.db.cluster-db.managed/gen-cluster-db})
+
+(def ^:private managed-db-types
+  "DB types whose backend is provisioned outside the test (e.g., AWS Aurora).
+  Their constructors receive the test options so they can read the user-supplied
+  --managed-db-config YAML file."
+  #{:managed})
 
 (defn- cluster-backend-db
-  [db-type]
+  [db-type opts]
   (if-let [v (get dbtype->gen-var db-type)]
-    ((requiring-resolve v))
+    (let [f (requiring-resolve v)]
+      (if (managed-db-types db-type) (f opts) (f)))
     (throw (ex-info "Unsupported DB for ScalarDB Cluster test" {:db db-type}))))
 
 (defn gen-db
-  [faults admin db-type]
+  [faults admin db-type & [opts]]
   (when (seq admin)
     (warn "The admin operations are ignored: " admin))
-  (let [backend-db (cluster-backend-db db-type)
+  (let [backend-db (cluster-backend-db db-type opts)
         db (ext/extend-db (db backend-db) (->ExtCluster backend-db))]
     [db (n/nemesis-package db 60 faults) 1]))

--- a/scalardb/src/scalardb/db/cluster_db/managed.clj
+++ b/scalardb/src/scalardb/db/cluster_db/managed.clj
@@ -1,22 +1,30 @@
 (ns scalardb.db.cluster-db.managed
-  "Backend for externally-provisioned managed DBs (e.g., AWS Aurora, Cloud SQL).
+  "Backend for externally-provisioned managed DBs (e.g., AWS Aurora, Aurora
+  MySQL, Amazon DynamoDB, Azure Cosmos DB for NoSQL).
   install!/configure!/start!/wipe! are no-ops; connection details come from a
   user-supplied YAML file passed via --managed-db-config.
 
   YAML schema:
-    Either provide 'jdbc-url' (used as-is), or 'subprotocol' + 'host'
-    (URL is built as jdbc:<subprotocol>://<host>:<port>/<database>).
-    'username' is required. 'password', 'port', and 'database' are optional;
-    defaults are provided for known subprotocols (postgresql, mysql)."
+    storage:        Required. One of 'jdbc', 'dynamo', 'cosmos'.
+    contact-points: For storage=jdbc, an explicit JDBC URL (alternative to
+                    subprotocol+host below). For storage=dynamo, the AWS
+                    region. For storage=cosmos, the Cosmos DB URI.
+    subprotocol, host, port, database:
+                    For storage=jdbc only. If contact-points is not given, the
+                    URL is built as jdbc:<subprotocol>://<host>:<port>/<db>.
+                    Defaults are provided for postgresql/mysql.
+    username:       Required for jdbc and dynamo. Ignored for cosmos.
+    password:       Required."
   (:require [clj-yaml.core :as yaml]
             [clojure.tools.logging :refer [info warn]]
             [scalardb.core :as scalar]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
   (:import (java.util Properties)))
 
+(def ^:private valid-storages #{"jdbc" "dynamo" "cosmos"})
+
 (def ^:private subprotocol-defaults
-  "Default port and database per JDBC subprotocol. Add entries for new
-  managed DB families that follow the jdbc:<subprotocol>://host:port/db form."
+  "Default port and database per JDBC subprotocol."
   {"postgresql" {:port 5432 :database "postgres"}
    "mysql"      {:port 3306 :database scalar/KEYSPACE}})
 
@@ -25,37 +33,61 @@
   (when (or (nil? path) (and (string? path) (empty? path)))
     (throw (ex-info "Managed DB backend requires --managed-db-config <file>"
                     {:option "--managed-db-config"})))
-  (let [config (-> path slurp yaml/parse-string)]
-    (when-not (or (:jdbc-url config)
-                  (and (:subprotocol config) (:host config)))
-      (throw (ex-info
-              "Managed DB config needs 'jdbc-url' or both 'subprotocol' and 'host'"
-              {:path path})))
-    (when-not (:username config)
-      (throw (ex-info "Managed DB config is missing 'username'" {:path path})))
+  (let [config (-> path slurp yaml/parse-string)
+        {:keys [storage contact-points subprotocol host username password]} config]
+    (when-not (valid-storages storage)
+      (throw (ex-info (str "Managed DB config 'storage' must be one of "
+                           valid-storages)
+                      {:path path :storage storage})))
+    (case storage
+      "jdbc"
+      (when-not (or contact-points (and subprotocol host))
+        (throw (ex-info
+                (str "Managed DB config (jdbc): needs 'contact-points' "
+                     "or both 'subprotocol' and 'host'")
+                {:path path})))
+
+      ("dynamo" "cosmos")
+      (when-not contact-points
+        (throw (ex-info
+                (str "Managed DB config (" storage
+                     "): 'contact-points' is required")
+                {:path path}))))
+    (when (and (#{"jdbc" "dynamo"} storage) (not username))
+      (throw (ex-info (str "Managed DB config (" storage
+                           "): 'username' is required")
+                      {:path path})))
+    (when-not password
+      (throw (ex-info "Managed DB config: 'password' is required"
+                      {:path path})))
     config))
 
-(defn- build-jdbc-url
-  [{:keys [jdbc-url subprotocol host port database]}]
-  (or jdbc-url
-      (let [defaults (get subprotocol-defaults subprotocol)
-            actual-port (or port (:port defaults))
-            actual-db (or database (:database defaults))]
-        (when-not (and actual-port actual-db)
-          (throw (ex-info
-                  (str "Managed DB config: cannot derive port/database for "
-                       "subprotocol '" subprotocol "'. Provide them explicitly "
-                       "or use 'jdbc-url'.")
-                  {:subprotocol subprotocol})))
-        (str "jdbc:" subprotocol "://" host \: actual-port \/ actual-db))))
+(defn- resolve-contact-points
+  "Returns the value to set as scalar.db.contact_points.
+  For jdbc: an explicit URL if provided, otherwise built from parts.
+  For dynamo/cosmos: the configured contact-points string (region or URI)."
+  [{:keys [storage contact-points subprotocol host port database]}]
+  (if (= storage "jdbc")
+    (or contact-points
+        (let [defaults (get subprotocol-defaults subprotocol)
+              actual-port (or port (:port defaults))
+              actual-db (or database (:database defaults))]
+          (when-not (and actual-port actual-db)
+            (throw (ex-info
+                    (str "Managed DB config: cannot derive port/database for "
+                         "subprotocol '" subprotocol "'. Provide them "
+                         "explicitly or use 'contact-points'.")
+                    {:subprotocol subprotocol})))
+          (str "jdbc:" subprotocol "://" host \: actual-port \/ actual-db)))
+    contact-points))
 
 (defrecord ClusterDbManaged [config]
   ClusterDb
-  (get-storage-type [_] "jdbc")
+  (get-storage-type [_] (:storage config))
 
-  (get-contact-points [_] (build-jdbc-url config))
+  (get-contact-points [_] (resolve-contact-points config))
 
-  (get-username [_] (:username config))
+  (get-username [_] (or (:username config) ""))
 
   (get-password [_] (or (:password config) ""))
 
@@ -74,10 +106,10 @@
 
   (create-storage-properties [_ _]
     (doto (Properties.)
-      (.setProperty "scalar.db.storage" "jdbc")
-      (.setProperty "scalar.db.contact_points" (build-jdbc-url config))
-      (.setProperty "scalar.db.username" (str (:username config)))
-      (.setProperty "scalar.db.password" (str (or (:password config) ""))))))
+      (.setProperty "scalar.db.storage" (:storage config))
+      (.setProperty "scalar.db.contact_points" (resolve-contact-points config))
+      (.setProperty "scalar.db.username" (str (or (:username config) "")))
+      (.setProperty "scalar.db.password" (str (:password config))))))
 
 (defn gen-cluster-db
   [opts]

--- a/scalardb/src/scalardb/db/cluster_db/managed.clj
+++ b/scalardb/src/scalardb/db/cluster_db/managed.clj
@@ -1,0 +1,84 @@
+(ns scalardb.db.cluster-db.managed
+  "Backend for externally-provisioned managed DBs (e.g., AWS Aurora, Cloud SQL).
+  install!/configure!/start!/wipe! are no-ops; connection details come from a
+  user-supplied YAML file passed via --managed-db-config.
+
+  YAML schema:
+    Either provide 'jdbc-url' (used as-is), or 'subprotocol' + 'host'
+    (URL is built as jdbc:<subprotocol>://<host>:<port>/<database>).
+    'username' is required. 'password', 'port', and 'database' are optional;
+    defaults are provided for known subprotocols (postgresql, mysql)."
+  (:require [clj-yaml.core :as yaml]
+            [clojure.tools.logging :refer [info warn]]
+            [scalardb.core :as scalar]
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+  (:import (java.util Properties)))
+
+(def ^:private subprotocol-defaults
+  "Default port and database per JDBC subprotocol. Add entries for new
+  managed DB families that follow the jdbc:<subprotocol>://host:port/db form."
+  {"postgresql" {:port 5432 :database "postgres"}
+   "mysql"      {:port 3306 :database scalar/KEYSPACE}})
+
+(defn- load-config
+  [path]
+  (when (or (nil? path) (and (string? path) (empty? path)))
+    (throw (ex-info "Managed DB backend requires --managed-db-config <file>"
+                    {:option "--managed-db-config"})))
+  (let [config (-> path slurp yaml/parse-string)]
+    (when-not (or (:jdbc-url config)
+                  (and (:subprotocol config) (:host config)))
+      (throw (ex-info
+              "Managed DB config needs 'jdbc-url' or both 'subprotocol' and 'host'"
+              {:path path})))
+    (when-not (:username config)
+      (throw (ex-info "Managed DB config is missing 'username'" {:path path})))
+    config))
+
+(defn- build-jdbc-url
+  [{:keys [jdbc-url subprotocol host port database]}]
+  (or jdbc-url
+      (let [defaults (get subprotocol-defaults subprotocol)
+            actual-port (or port (:port defaults))
+            actual-db (or database (:database defaults))]
+        (when-not (and actual-port actual-db)
+          (throw (ex-info
+                  (str "Managed DB config: cannot derive port/database for "
+                       "subprotocol '" subprotocol "'. Provide them explicitly "
+                       "or use 'jdbc-url'.")
+                  {:subprotocol subprotocol})))
+        (str "jdbc:" subprotocol "://" host \: actual-port \/ actual-db))))
+
+(defrecord ClusterDbManaged [config]
+  ClusterDb
+  (get-storage-type [_] "jdbc")
+
+  (get-contact-points [_] (build-jdbc-url config))
+
+  (get-username [_] (:username config))
+
+  (get-password [_] (or (:password config) ""))
+
+  (install! [_]
+    (info "Managed DB; skipping install"))
+
+  (configure! [_]
+    (info "Managed DB; skipping configure"))
+
+  (start! [_]
+    (info "Managed DB; skipping start"))
+
+  (wipe! [_]
+    (warn "Managed DB; skipping wipe."
+          " Existing test data is not cleaned up automatically."))
+
+  (create-storage-properties [_ _]
+    (doto (Properties.)
+      (.setProperty "scalar.db.storage" "jdbc")
+      (.setProperty "scalar.db.contact_points" (build-jdbc-url config))
+      (.setProperty "scalar.db.username" (str (:username config)))
+      (.setProperty "scalar.db.password" (str (or (:password config) ""))))))
+
+(defn gen-cluster-db
+  [opts]
+  (->ClusterDbManaged (load-config (:managed-db-config opts))))

--- a/scalardb/src/scalardb/db/cluster_db/managed.clj
+++ b/scalardb/src/scalardb/db/cluster_db/managed.clj
@@ -1,19 +1,20 @@
 (ns scalardb.db.cluster-db.managed
   "Backend for externally-provisioned managed DBs (e.g., AWS Aurora, Aurora
-  MySQL, Amazon DynamoDB, Azure Cosmos DB for NoSQL).
-  install!/configure!/start!/wipe! are no-ops; connection details come from a
-  user-supplied YAML file passed via --managed-db-config.
+  MySQL, Amazon DynamoDB, Azure Cosmos DB for NoSQL, an external Cassandra
+  cluster). install!/configure!/start!/wipe! are no-ops; connection details
+  come from a user-supplied YAML file passed via --managed-db-config.
 
   YAML schema:
-    storage:        Required. One of 'jdbc', 'dynamo', 'cosmos'.
+    storage:        Required. One of 'jdbc', 'dynamo', 'cosmos', 'cassandra'.
     contact-points: For storage=jdbc, an explicit JDBC URL (alternative to
                     subprotocol+host below). For storage=dynamo, the AWS
-                    region. For storage=cosmos, the Cosmos DB URI.
+                    region. For storage=cosmos, the Cosmos DB URI. For
+                    storage=cassandra, comma-separated host(s).
     subprotocol, host, port, database:
                     For storage=jdbc only. If contact-points is not given, the
                     URL is built as jdbc:<subprotocol>://<host>:<port>/<db>.
                     Defaults are provided for postgresql/mysql.
-    username:       Required for jdbc and dynamo. Ignored for cosmos.
+    username:       Required for jdbc, dynamo, and cassandra. Ignored for cosmos.
     password:       Required."
   (:require [clj-yaml.core :as yaml]
             [clojure.tools.logging :refer [info warn]]
@@ -21,7 +22,7 @@
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
   (:import (java.util Properties)))
 
-(def ^:private valid-storages #{"jdbc" "dynamo" "cosmos"})
+(def ^:private valid-storages #{"jdbc" "dynamo" "cosmos" "cassandra"})
 
 (def ^:private subprotocol-defaults
   "Default port and database per JDBC subprotocol."
@@ -47,13 +48,13 @@
                      "or both 'subprotocol' and 'host'")
                 {:path path})))
 
-      ("dynamo" "cosmos")
+      ("dynamo" "cosmos" "cassandra")
       (when-not contact-points
         (throw (ex-info
                 (str "Managed DB config (" storage
                      "): 'contact-points' is required")
                 {:path path}))))
-    (when (and (#{"jdbc" "dynamo"} storage) (not username))
+    (when (and (#{"jdbc" "dynamo" "cassandra"} storage) (not username))
       (throw (ex-info (str "Managed DB config (" storage
                            "): 'username' is required")
                       {:path path})))

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -30,7 +30,8 @@
    "tidb" :tidb
    "sqlserver" :sqlserver
    "oracle" :oracle
-   "db2" :db2})
+   "db2" :db2
+   "managed" :managed})
 
 (def workload-keys
   "A map of test workload keys."
@@ -100,6 +101,10 @@
 
    [nil "--config-file CONFIG_FILE"
     "ScalarDB config file. When this is given, other configuration options are ignored."
+    :default ""]
+
+   [nil "--managed-db-config FILE"
+    "YAML file with managed DB connection details (host, port, database, username, password). Required for managed DB types like aurora-postgres."
     :default ""]])
 
 (defn- test-name
@@ -111,7 +116,7 @@
 
 (defn- gen-db
   "Returns [extended-db constructed-nemesis num-max-nodes]."
-  [db-type faults admin]
+  [opts db-type faults admin]
   (let [gen-db-sym (if (= (env :cluster?) "true")
                      (do (require 'scalardb.db.cluster)
                          'scalardb.db.cluster/gen-db)
@@ -122,7 +127,7 @@
                                       'scalardb.db.postgres/gen-db)
                        (throw (ex-info "Unsupported DB" {:db db-type}))))
         gen-db-fn (resolve gen-db-sym)]
-    (gen-db-fn faults admin db-type)))
+    (gen-db-fn faults admin db-type opts)))
 
 (defn- gen-test-opt-spec
   []
@@ -144,7 +149,7 @@
 
 (defn scalardb-test
   [base-opts db-type workload-key faults admin]
-  (let [[db nemesis max-nodes] (gen-db db-type faults admin)
+  (let [[db nemesis max-nodes] (gen-db base-opts db-type faults admin)
         consistency-model (->> base-opts :consistency-model (mapv keyword))
         workload-opts (merge base-opts
                              scalardb-opts

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -104,7 +104,7 @@
     :default ""]
 
    [nil "--managed-db-config FILE"
-    "YAML file with managed DB connection details (host, port, database, username, password). Required for managed DB types like aurora-postgres."
+    "YAML file with managed DB connection details. Supported fields include host, port, database, username, password, jdbc-url (full override), and subprotocol (used to build the JDBC URL with defaults). Required for managed DB types like aurora-postgres."
     :default ""]])
 
 (defn- test-name


### PR DESCRIPTION
## Description
I'd like to support managed DBs in ScalarDB Cluster tests.
It would be pretty messy and require other tools like `aws` if the Jepsen test sets up these managed DBs, especially the network.
I believe that it is useful to pass endpoint/credentials of the existing managed DB rather than full setting up a new one.

I've confirmed this test is working with AWS Aurora Postgres.

P.S. confirmed AWS DynamoDB too.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add `managed.clj` to make ScalarDB properties from the given config file
- Add `--db managed` and `--managed-db-config FILE`  

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
