### PR TITLE
Fix YugabyteDB endpoint

### DIFF
--- a/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
@@ -15,7 +15,7 @@
   (get-storage-type [_] "jdbc")
 
   (get-contact-points [_]
-    "jdbc:postgresql://yb-tservers.default.svc.cluster.local:5433/yugabyte")
+    "jdbc:yugabytedb://yb-tservers.default.svc.cluster.local:5433/yugabyte")
 
   (get-username [_] YUGABYTEDB_USER)
 
@@ -60,7 +60,7 @@
       (doto (Properties.)
         (.setProperty "scalar.db.storage" "jdbc")
         (.setProperty "scalar.db.contact_points"
-                      (str "jdbc:postgresql://" ip ":5433/yugabyte"))
+                      (str "jdbc:yugabytedb://" ip ":5433/yugabyte"))
         (.setProperty "scalar.db.username" YUGABYTEDB_USER)
         (.setProperty "scalar.db.password" YUGABYTEDB_PASSWORD)))))
 


### PR DESCRIPTION
## Description
The endpoint for YugabyteDB in the ScalarDB Cluster test is incorrect.
It worked, but it should start with `jdbc:yugabytedb`.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Correct the endpoint for YugabyteDB

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
