### PR TITLE
Testing on AWS EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,16 @@ aws ec2 create-tags --region ${REGION} \
     --tags Key=kubernetes.io/role/elb,Value=1
 ```
 
-2. Allow the control machine's IP in the load balancers' security group on the relevant ports (e.g. `60053` for Envoy, `5432` for PostgreSQL).
+2. Allow the control machine's IP in the load balancers' security group on the relevant ports (e.g. `60053` for Envoy, `5432` for PostgreSQL). Use the control's **public** IP as a `/32` (the source the node/LB sees), not its LAN address:
+```sh
+YOUR_IP=$(curl -s https://checkip.amazonaws.com)
+aws ec2 authorize-security-group-ingress --region ${REGION} \
+    --group-id ${LB_SG_ID} \
+    --protocol tcp --port 60053 --cidr ${YOUR_IP}/32   # Envoy
+aws ec2 authorize-security-group-ingress --region ${REGION} \
+    --group-id ${LB_SG_ID} \
+    --protocol tcp --port 5432 --cidr ${YOUR_IP}/32     # PostgreSQL
+```
 
 Then run the test, pointing it at your EKS cluster and requesting internet-facing LoadBalancers:
 ```sh
@@ -126,4 +135,13 @@ lein with-profile cluster run test --workload transfer --db postgres \
 
 Notes:
   - The subnet tags and security group rules (like the `StorageClass`) are one-time cluster setup that persists across test runs — the test's wipe does not remove them — so they are best handled by your IaC rather than applied each run.
-  - Db2 and Oracle backends are exposed via a NodePort on the Kubernetes node rather than a `LoadBalancer`, so `--lb-internet-facing` does not apply to them; external access to those requires the node's external IP and a security group rule on the NodePort.
+  - Db2 and Oracle backends are exposed via a NodePort on the Kubernetes node rather than a `LoadBalancer`, so `--lb-internet-facing` does not apply to them. External access goes to `<node-external-IP>:<nodePort>` (`31500` for Db2, `31521` for Oracle), which requires the worker nodes to have public IPs (public subnets) and a rule on the **node** security group (distinct from the LoadBalancer security group above) allowing your IP to those NodePorts:
+```sh
+YOUR_IP=$(curl -s https://checkip.amazonaws.com)
+aws ec2 authorize-security-group-ingress --region ${REGION} \
+    --group-id ${NODE_SG_ID} \
+    --protocol tcp --port 31500 --cidr ${YOUR_IP}/32   # Db2
+aws ec2 authorize-security-group-ingress --region ${REGION} \
+    --group-id ${NODE_SG_ID} \
+    --protocol tcp --port 31521 --cidr ${YOUR_IP}/32   # Oracle
+```

--- a/README.md
+++ b/README.md
@@ -79,3 +79,51 @@ lein with-profile cluster run test --workload transfer --db postgres \
   - `GITHUB_USER`: Your GitHub username, used to authenticate with ghcr.io for pulling the ScalarDB Cluster Docker image.
   - `GITHUB_ACCESS_TOKEN`: A GitHub access token with permissions to pull images from ghcr.io.
   - All other parameters match those used in standard ScalarDB tests
+
+## Prerequisite for Amazon EKS: a default StorageClass
+The test provisions a backend database (e.g. PostgreSQL) whose pod requests a `PersistentVolumeClaim`. A local `kind` cluster ships with a default `StorageClass`, but **an EKS cluster has none by default**, so the PVC stays `Pending` and the backend pod never starts. Create a default `StorageClass` before running the test.
+
+For an EKS Auto Mode cluster:
+```sh
+kubectl apply -f - <<'EOF'
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: auto-ebs-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  encrypted: "true"
+EOF
+```
+  - On a non-Auto-Mode EKS cluster, install the EBS CSI driver add-on and use the `ebs.csi.aws.com` provisioner instead.
+  - Exactly one `StorageClass` should carry the `storageclass.kubernetes.io/is-default-class: "true"` annotation.
+  - Verify with `kubectl get storageclass`; the default is shown as `... (default)`.
+  - This is cluster setup, so it's best added to whatever provisions your EKS cluster (e.g. your IaC) rather than applied by hand each time.
+
+## Prerequisite for Amazon EKS: external access to the LoadBalancers
+The Jepsen control connects to the cluster over `LoadBalancer` services: the ScalarDB Cluster (Envoy) for transactions and schema loading, and the backend DB, which the test's checker reaches directly via the ScalarDB storage API. With a local `kind` cluster (using MetalLB) these are reachable from the control machine, but on EKS they are not reachable from outside the VPC by default. When the control runs outside the VPC (e.g. on your laptop), complete the one-time setup below **before** running the test.
+
+1. Tag the public subnets so the AWS load balancer controller can place internet-facing NLBs. This must be done before the test creates the `LoadBalancer` services; otherwise they stay `Pending` with a `FailedBuildModel` event, and tagging afterwards does not retrigger provisioning.
+```sh
+aws ec2 create-tags --region ${REGION} \
+    --resources ${SUBNET_ID_1} ${SUBNET_ID_2} ${SUBNET_ID_3} \
+    --tags Key=kubernetes.io/role/elb,Value=1
+```
+
+2. Allow the control machine's IP in the load balancers' security group on the relevant ports (e.g. `60053` for Envoy, `5432` for PostgreSQL).
+
+Then run the test, pointing it at your EKS cluster and requesting internet-facing LoadBalancers:
+```sh
+lein with-profile cluster run test --workload transfer --db postgres \
+    --kubeconfig ~/.kube/eks-jepsen-test --lb-internet-facing
+```
+  - `--kubeconfig FILE`: kubeconfig file for kubectl/helm (uses that file's current context).
+  - `--lb-internet-facing`: annotates the Envoy and backend DB `LoadBalancer` services as internet-facing so the control can reach them.
+
+Notes:
+  - The subnet tags and security group rules (like the `StorageClass`) are one-time cluster setup that persists across test runs — the test's wipe does not remove them — so they are best handled by your IaC rather than applied each run.
+  - Db2 and Oracle backends are exposed via a NodePort on the Kubernetes node rather than a `LoadBalancer`, so `--lb-internet-facing` does not apply to them; external access to those requires the node's external IP and a security group rule on the NodePort.

--- a/README.md
+++ b/README.md
@@ -131,11 +131,12 @@ lein with-profile cluster run test --workload transfer --db postgres \
     --kubeconfig ~/.kube/eks-jepsen-test --lb-internet-facing
 ```
   - `--kubeconfig FILE`: kubeconfig file for kubectl/helm (uses that file's current context).
-  - `--lb-internet-facing`: annotates the Envoy and backend DB `LoadBalancer` services as internet-facing so the control can reach them.
+  - `--lb-internet-facing`: annotates the Envoy and backend DB `LoadBalancer` services as internet-facing so the control can reach them. This is AWS-specific: on EKS a `LoadBalancer` is internal by default, so the annotation is required. On GKE/AKS, `LoadBalancer` services are external by default and the annotation is a no-op, so the flag is not needed there.
 
 Notes:
   - The subnet tags and security group rules (like the `StorageClass`) are one-time cluster setup that persists across test runs — the test's wipe does not remove them — so they are best handled by your IaC rather than applied each run.
-  - Db2 and Oracle backends are exposed via a NodePort on the Kubernetes node rather than a `LoadBalancer`, so `--lb-internet-facing` does not apply to them. External access goes to `<node-external-IP>:<nodePort>` (`31500` for Db2, `31521` for Oracle), which requires the worker nodes to have public IPs (public subnets) and a rule on the **node** security group (distinct from the LoadBalancer security group above) allowing your IP to those NodePorts:
+  - Db2 and Oracle backends are exposed via a NodePort on the Kubernetes node rather than a `LoadBalancer`, so `--lb-internet-facing` does not apply to them. The test reaches them at `<node-external-IP>:<nodePort>` (`31500` for Db2, `31521` for Oracle): it automatically uses the node's `ExternalIP` when the node reports one (falling back to the `InternalIP`, e.g. on local `kind`), so no flag is required. This requires the worker nodes to have public IPs (public subnets) and a firewall/security-group rule allowing your IP to those NodePorts — on the **node** security group on EKS (distinct from the LoadBalancer security group above), or a firewall rule on the node network tag on GKE:
+On EKS (node security group):
 ```sh
 YOUR_IP=$(curl -s https://checkip.amazonaws.com)
 aws ec2 authorize-security-group-ingress --region ${REGION} \
@@ -145,3 +146,15 @@ aws ec2 authorize-security-group-ingress --region ${REGION} \
     --group-id ${NODE_SG_ID} \
     --protocol tcp --port 31521 --cidr ${YOUR_IP}/32   # Oracle
 ```
+On GKE (firewall rule targeting the node network tag; find the tag with
+`gcloud compute instances list --format="table(name, tags.items)"`):
+```sh
+YOUR_IP=$(curl -s https://checkip.amazonaws.com)
+gcloud compute firewall-rules create allow-scalardb-nodeport \
+    --project=${PROJECT} --network=${NETWORK} \
+    --direction=INGRESS --action=ALLOW \
+    --rules=tcp:31500,tcp:31521 \
+    --source-ranges=${YOUR_IP}/32 \
+    --target-tags=${NODE_NETWORK_TAG}
+```
+Note that GKE nodes have public IPs only on a public cluster; a private (or Autopilot) cluster's nodes report no `ExternalIP`, so the test falls back to the unreachable `InternalIP` and NodePort access from outside the VPC is not possible without a bastion/tunnel.

--- a/scalardb/oracle-free-jepsen.yaml
+++ b/scalardb/oracle-free-jepsen.yaml
@@ -30,6 +30,14 @@ spec:
         app: oracle-scalardb-cluster
     spec:
       terminationGracePeriodSeconds: 60
+      # The gvenzl/oracle-free image runs as the non-root "oracle" user
+      # (uid/gid 54321). On EKS the EBS CSI driver mounts a fresh volume owned
+      # by root:root, so that user cannot create its datafiles under
+      # /opt/oracle/oradata. fsGroup makes the kubelet chown/setgid the mounted
+      # volume to gid 54321 so the container can write. (kind's local-path
+      # provisioner mounts world-writable, so this is not needed there.)
+      securityContext:
+        fsGroup: 54321
       containers:
         - name: oracle
           image: ghcr.io/gvenzl/oracle-free:23-slim

--- a/scalardb/src/scalardb/core.clj
+++ b/scalardb/src/scalardb/core.clj
@@ -8,7 +8,7 @@
            (com.scalar.db.schemaloader SchemaLoader)
            (com.scalar.db.service TransactionFactory
                                   StorageFactory)
-           (com.scalar.db.transaction.consensuscommit Coordinator)))
+           (com.scalar.db.transaction.consensuscommit CoordinatorStateAccessor)))
 
 (def ^:const RETRIES 20)
 (def ^:const RETRIES_FOR_RECONNECTION 3)
@@ -248,7 +248,7 @@
       (when (nil? @(:storage test))
         (prepare-storage-service! test))
       (with-retry prepare-storage-service! test
-        (let [coordinator (Coordinator. @(:storage test))
+        (let [coordinator (CoordinatorStateAccessor. @(:storage test))
               committed (map (partial is-committed-state? coordinator) ids)]
           (if (some nil? committed)
             nil

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -189,10 +189,7 @@
   (k8s/collect-logs! test {:selector NODE_SELECTOR
                            :output-dir (store/path! test "pods")}))
 
-(defn get-load-balancer-ip
-  "Get the external address of a LoadBalancer service whose name includes
-  prefix. Returns the ingress IP when present, otherwise the DNS hostname
-  (clouds like AWS expose LoadBalancers via a hostname rather than an IP)."
+(defn- find-load-balancer-ip
   [test prefix]
   (->> (k8s/services test {})
        :items
@@ -201,6 +198,23 @@
        (keep #(let [ingress (get-in % [:status :loadBalancer :ingress 0])]
                 (or (:ip ingress) (:hostname ingress))))
        first))
+
+(defn get-load-balancer-ip
+  "Get the external address of a LoadBalancer service whose name includes
+  prefix. Returns the ingress IP when present, otherwise the DNS hostname
+  (clouds like AWS expose LoadBalancers via a hostname rather than an IP).
+  Cloud providers provision the LoadBalancer asynchronously, so poll until an
+  address appears rather than returning nil the instant after service creation."
+  ([test prefix] (get-load-balancer-ip test prefix TIMEOUT_SEC INTERVAL_SEC))
+  ([test prefix timeout-sec interval-sec]
+   (or (find-load-balancer-ip test prefix)
+       (if (<= timeout-sec 0)
+         (throw (ex-info "Timed out waiting for LoadBalancer address"
+                         {:prefix prefix}))
+         (do
+           (info "waiting for LoadBalancer address for" prefix "...")
+           (Thread/sleep (* interval-sec 1000))
+           (recur test prefix (- timeout-sec interval-sec) interval-sec))))))
 
 (defn get-k8s-node-ip
   "Get the IP of a Kubernetes node used to reach NodePort-exposed backends
@@ -294,9 +308,7 @@
   (create-properties
     [_ test]
     (or (ext/load-config test)
-        (let [ip (get-load-balancer-ip test (str CLUSTER_NAME "-envoy"))
-              ip2 (get-load-balancer-ip test (str CLUSTER2_NAME "-envoy"))
-              create-fn
+        (let [create-fn
               (fn [ip]
                 (let [client-side-optimizations-enabled (str (:enable-cluster-client-side-optimizations test))]
                   (doto (Properties.)
@@ -305,8 +317,9 @@
                     (.setProperty "scalar.db.cluster.client.piggyback_begin.enabled" client-side-optimizations-enabled)
                     (.setProperty "scalar.db.cluster.client.write_buffering.enabled" client-side-optimizations-enabled))))]
           (if (need-two-clusters? test)
-            (mapv create-fn [ip ip2])
-            (create-fn ip)))))
+            (mapv (comp create-fn #(get-load-balancer-ip test (str % "-envoy")))
+                  [CLUSTER_NAME CLUSTER2_NAME])
+            (create-fn (get-load-balancer-ip test (str CLUSTER_NAME "-envoy")))))))
   (create-storage-properties [_ test]
     (cluster-db/create-storage-properties backend-db test)))
 

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -25,6 +25,9 @@
 (def ^:private ^:const CLUSTER2_NAME (str CLUSTER_NAME "-2"))
 (def ^:private ^:const NODE_SELECTOR "app.kubernetes.io/app=scalardb-cluster")
 
+(def ^:private ^:const LB_SCHEME_ANNOTATION
+  "service.beta.kubernetes.io/aws-load-balancer-scheme")
+
 (def ^:private ^:const CLUSTER_VALUES
   {:envoy {:enabled true
            :service {:type "LoadBalancer"}}
@@ -89,6 +92,25 @@
   [test]
   (str/includes? (:name test) "2pc"))
 
+(defn- expose-loadbalancers!
+  "When --lb-internet-facing is set, annotate every LoadBalancer service in the
+  namespace so the cloud provisions it internet-facing. This covers both the
+  Envoy entry point and each backend DB's service: the checker reaches the
+  backend directly via the ScalarDB storage API, so the backend must be
+  reachable from outside the cloud network too. Backends exposed via NodePort +
+  node IP (e.g. Db2, Oracle) are not LoadBalancers and need separate handling.
+  The annotation is ignored by providers that don't recognize it (e.g. MetalLB)."
+  [test]
+  (when (:lb-internet-facing test)
+    (doseq [name (->> (k8s/services test {})
+                      :items
+                      (filter #(= "LoadBalancer" (get-in % [:spec :type])))
+                      (map #(get-in % [:metadata :name])))]
+      (info "exposing LoadBalancer as internet-facing:" name)
+      (k8s/kubectl! test :annotate :svc name
+                    (str LB_SCHEME_ANNOTATION "=internet-facing")
+                    :--overwrite))))
+
 (defn- install!
   "Install prerequisites.
   You should already have installed kind (or similar tool), kubectl and helm."
@@ -130,7 +152,11 @@
                            :namespace "default"}))
     (.delete (File. CLUSTER_VALUES_YAML)))
 
-  (cm/setup! test {}))
+  (cm/setup! test {})
+
+  ;; Expose the Envoy and backend DB LoadBalancers to outside the cloud network
+  ;; when requested (e.g. a Jepsen control running outside the VPC on EKS).
+  (expose-loadbalancers! test))
 
 (defn- wipe!
   [test backend-db]
@@ -164,14 +190,16 @@
                            :output-dir (store/path! test "pods")}))
 
 (defn get-load-balancer-ip
-  "Get the external IP of a LoadBalancer service whose name includes prefix"
+  "Get the external address of a LoadBalancer service whose name includes
+  prefix. Returns the ingress IP when present, otherwise the DNS hostname
+  (clouds like AWS expose LoadBalancers via a hostname rather than an IP)."
   [test prefix]
   (->> (k8s/services test {})
        :items
        (filter #(str/includes? (get-in % [:metadata :name]) prefix))
        (filter #(= "LoadBalancer" (get-in % [:spec :type])))
-       (map #(get-in % [:status :loadBalancer :ingress 0 :ip]))
-       (remove nil?)
+       (keep #(let [ingress (get-in % [:status :loadBalancer :ingress 0])]
+                (or (:ip ingress) (:hostname ingress))))
        first))
 
 (defn get-k8s-node-ip

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -203,14 +203,21 @@
        first))
 
 (defn get-k8s-node-ip
-  "Get the internal IP of a Kubernetes node"
+  "Get the IP of a Kubernetes node used to reach NodePort-exposed backends
+  (e.g. Db2, Oracle). With --lb-internet-facing the control runs outside the
+  cloud network, so prefer the node's ExternalIP (its public IP); otherwise use
+  the InternalIP, which is what an in-VPC or local (kind) control can reach.
+  Falls back to InternalIP if no ExternalIP is reported."
   [test]
-  (->> (k8s/nodes test)
-       :items
-       (mapcat #(get-in % [:status :addresses]))
-       (filter #(= "InternalIP" (:type %)))
-       (map :address)
-       first))
+  (let [addresses (->> (k8s/nodes test)
+                       :items
+                       (mapcat #(get-in % [:status :addresses])))
+        by-type (fn [t] (->> addresses
+                             (filter #(= t (:type %)))
+                             (map :address)
+                             first))]
+    (or (when (:lb-internet-facing test) (by-type "ExternalIP"))
+        (by-type "InternalIP"))))
 
 (defn- running-pods?
   "Check a live node."

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -93,23 +93,25 @@
   (str/includes? (:name test) "2pc"))
 
 (defn- expose-loadbalancers!
-  "When --lb-internet-facing is set, annotate every LoadBalancer service in the
-  namespace so the cloud provisions it internet-facing. This covers both the
-  Envoy entry point and each backend DB's service: the checker reaches the
-  backend directly via the ScalarDB storage API, so the backend must be
-  reachable from outside the cloud network too. Backends exposed via NodePort +
-  node IP (e.g. Db2, Oracle) are not LoadBalancers and need separate handling.
-  The annotation is ignored by providers that don't recognize it (e.g. MetalLB)."
-  [test]
+  "When --lb-internet-facing is set, annotate the test's own LoadBalancer
+  services so the cloud provisions them internet-facing."
+  [test backend-db]
   (when (:lb-internet-facing test)
-    (doseq [name (->> (k8s/services test {})
-                      :items
-                      (filter #(= "LoadBalancer" (get-in % [:spec :type])))
-                      (map #(get-in % [:metadata :name])))]
-      (info "exposing LoadBalancer as internet-facing:" name)
-      (k8s/kubectl! test :annotate :svc name
-                    (str LB_SCHEME_ANNOTATION "=internet-facing")
-                    :--overwrite))))
+    (let [envoy-names (map #(str % "-envoy")
+                           (if (need-two-clusters? test)
+                             [CLUSTER_NAME CLUSTER2_NAME]
+                             [CLUSTER_NAME]))
+          names (remove nil? (conj envoy-names
+                                   (cluster-db/get-lb-service-name backend-db)))]
+      (doseq [name (->> (k8s/services test {})
+                        :items
+                        (filter #(= "LoadBalancer" (get-in % [:spec :type])))
+                        (map #(get-in % [:metadata :name]))
+                        (filter (fn [svc] (some #(str/includes? svc %) names))))]
+        (info "exposing LoadBalancer as internet-facing:" name)
+        (k8s/kubectl! test :annotate :svc name :-n (k8s/namespace test)
+                      (str LB_SCHEME_ANNOTATION "=internet-facing")
+                      :--overwrite)))))
 
 (defn- install!
   "Install prerequisites.
@@ -156,7 +158,7 @@
 
   ;; Expose the Envoy and backend DB LoadBalancers to outside the cloud network
   ;; when requested (e.g. a Jepsen control running outside the VPC on EKS).
-  (expose-loadbalancers! test))
+  (expose-loadbalancers! test backend-db))
 
 (defn- wipe!
   [test backend-db]

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -218,10 +218,11 @@
 
 (defn get-k8s-node-ip
   "Get the IP of a Kubernetes node used to reach NodePort-exposed backends
-  (e.g. Db2, Oracle). With --lb-internet-facing the control runs outside the
-  cloud network, so prefer the node's ExternalIP (its public IP); otherwise use
-  the InternalIP, which is what an in-VPC or local (kind) control can reach.
-  Falls back to InternalIP if no ExternalIP is reported."
+  (e.g. Db2, Oracle). Prefer the node's ExternalIP (its public IP) when the node
+  reports one, so a control outside the cloud network (e.g. on EKS/GKE) can
+  reach the NodePort; fall back to the InternalIP, which is what an in-VPC or
+  local (kind) control uses. kind nodes report no ExternalIP, so they keep using
+  the InternalIP."
   [test]
   (let [addresses (->> (k8s/nodes test)
                        :items
@@ -230,8 +231,7 @@
                              (filter #(= t (:type %)))
                              (map :address)
                              first))]
-    (or (when (:lb-internet-facing test) (by-type "ExternalIP"))
-        (by-type "InternalIP"))))
+    (or (by-type "ExternalIP") (by-type "InternalIP"))))
 
 (defn- running-pods?
   "Check a live node."

--- a/scalardb/src/scalardb/db/cluster_db/alloydb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/alloydb.clj
@@ -33,6 +33,8 @@
 
   (get-password [_] ALLOYDB_PASSWORD)
 
+  (get-lb-service-name [_] (str "al-" ALLOYDB_NAME))
+
   (install! [_ test]
     (helm/repo-add! test "jetstack" "https://charts.jetstack.io")
     (helm/repo-update! test)

--- a/scalardb/src/scalardb/db/cluster_db/cluster_db.clj
+++ b/scalardb/src/scalardb/db/cluster_db/cluster_db.clj
@@ -5,6 +5,7 @@
   (get-contact-points [this])
   (get-username [this])
   (get-password [this])
+  (get-lb-service-name [this])
   (install! [this test])
   (configure! [this test])
   (start! [this test])

--- a/scalardb/src/scalardb/db/cluster_db/db2.clj
+++ b/scalardb/src/scalardb/db/cluster_db/db2.clj
@@ -23,6 +23,9 @@
 
   (get-password [_] DB2_PASSWORD)
 
+  ;; Db2 is reached via NodePort + node IP, not a LoadBalancer.
+  (get-lb-service-name [_] nil)
+
   (install! [_ _])
 
   (configure! [_ test]

--- a/scalardb/src/scalardb/db/cluster_db/managed.clj
+++ b/scalardb/src/scalardb/db/cluster_db/managed.clj
@@ -92,6 +92,9 @@
 
   (get-password [_] (or (:password config) ""))
 
+  ;; External managed DB; there is no in-cluster LoadBalancer service.
+  (get-lb-service-name [_] nil)
+
   (install! [_ _]
     (info "Managed DB; skipping install"))
 

--- a/scalardb/src/scalardb/db/cluster_db/mariadb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mariadb.clj
@@ -23,6 +23,8 @@
 
   (get-password [_] MARIADB_PASSWORD)
 
+  (get-lb-service-name [_] MARIADB_NAME)
+
   (install! [_ test]
     (helm/repo-add! test "bitnami" "https://charts.bitnami.com/bitnami"))
 

--- a/scalardb/src/scalardb/db/cluster_db/mysql.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mysql.clj
@@ -23,6 +23,8 @@
 
   (get-password [_] MYSQL_PASSWORD)
 
+  (get-lb-service-name [_] MYSQL_NAME)
+
   (install! [_ test]
     (helm/repo-add! test "bitnami" "https://charts.bitnami.com/bitnami"))
 

--- a/scalardb/src/scalardb/db/cluster_db/oracle.clj
+++ b/scalardb/src/scalardb/db/cluster_db/oracle.clj
@@ -21,6 +21,9 @@
 
   (get-password [_] ORACLE_PASSWORD)
 
+  ;; Oracle is reached via NodePort + node IP, not a LoadBalancer.
+  (get-lb-service-name [_] nil)
+
   (install! [_ _])
 
   (configure! [_ test]

--- a/scalardb/src/scalardb/db/cluster_db/postgres.clj
+++ b/scalardb/src/scalardb/db/cluster_db/postgres.clj
@@ -21,6 +21,8 @@
 
   (get-password [_] POSTGRESQL_PASSWORD)
 
+  (get-lb-service-name [_] POSTGRESQL_NAME)
+
   (install! [_ test]
     (helm/repo-add! test "bitnami" "https://charts.bitnami.com/bitnami"))
 

--- a/scalardb/src/scalardb/db/cluster_db/sqlserver.clj
+++ b/scalardb/src/scalardb/db/cluster_db/sqlserver.clj
@@ -21,6 +21,8 @@
 
   (get-password [_] SQLSERVER_PASSWORD)
 
+  (get-lb-service-name [_] SQLSERVER_NAME)
+
   (install! [_ test]
     (helm/repo-add! test
                     "simcube"

--- a/scalardb/src/scalardb/db/cluster_db/tidb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/tidb.clj
@@ -24,6 +24,8 @@
 
   (get-password [_] TIDB_PASSWORD)
 
+  (get-lb-service-name [_] TIDB_NAME)
+
   (install! [_ test]
     (helm/repo-add! test "pingcap" "https://charts.pingcap.org/")
     (k8s/kubectl! test :create :namespace "tidb-admin")

--- a/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
@@ -22,6 +22,8 @@
 
   (get-password [_] YUGABYTEDB_PASSWORD)
 
+  (get-lb-service-name [_] YUGABYTEDB_LB_SERVICE)
+
   (install! [_ test]
     (helm/repo-add! test "yugabytedb" "https://charts.yugabyte.com"))
 

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -108,7 +108,7 @@
                   s))]
 
    [nil "--lb-internet-facing"
-    "if set, expose the ScalarDB Cluster (Envoy) LoadBalancer as internet-facing (e.g. on EKS, so a Jepsen control outside the VPC can reach it). Requires cloud-side setup such as tagged public subnets and security group rules. Ignored where the LB provider doesn't use the annotation (e.g. MetalLB)."
+    "if set, expose the ScalarDB Cluster (Envoy) and backend DB LoadBalancers as internet-facing (e.g. on EKS, so a Jepsen control outside the VPC can reach both the cluster and, via the storage API, the backend). Requires cloud-side setup such as tagged public subnets and security group rules. Ignored where the LB provider doesn't use the annotation (e.g. MetalLB)."
     :default false]
 
    [nil "--config-file CONFIG_FILE"

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -99,6 +99,18 @@
    [nil "--enable-cluster-client-side-optimizations" "if set, ScalarDB Cluster client-side optimizations are enabled"
     :default false]
 
+   [nil "--kubeconfig FILE"
+    "Path to the kubeconfig file used for kubectl/helm in ScalarDB Cluster tests. Defaults to the host's default kubeconfig."
+    :default nil
+    :parse-fn (fn [s]
+                (if (string/starts-with? s "~/")
+                  (str (System/getProperty "user.home") (subs s 1))
+                  s))]
+
+   [nil "--lb-internet-facing"
+    "if set, expose the ScalarDB Cluster (Envoy) LoadBalancer as internet-facing (e.g. on EKS, so a Jepsen control outside the VPC can reach it). Requires cloud-side setup such as tagged public subnets and security group rules. Ignored where the LB provider doesn't use the annotation (e.g. MetalLB)."
+    :default false]
+
    [nil "--config-file CONFIG_FILE"
     "ScalarDB config file. When this is given, other configuration options are ignored."
     :default ""]
@@ -155,7 +167,11 @@
         workload-opts (merge base-opts
                              scalardb-opts
                              {:nodes (vec (take max-nodes (:nodes base-opts)))
-                              :consistency-model consistency-model})
+                              :consistency-model consistency-model
+                              ;; jepsen-k8s reads [:k8s :kubeconfig] to pass
+                              ;; --kubeconfig to kubectl/helm. nil means the
+                              ;; host's default kubeconfig.
+                              :k8s {:kubeconfig (:kubeconfig base-opts)}})
         workload ((workload-key workloads) workload-opts)]
     (merge tests/noop-test
            workload-opts

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -1,6 +1,7 @@
 (ns scalardb.runner
   (:gen-class)
-  (:require [clojure.string :as string]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [environ.core :refer [env]]
             [jepsen
              [core :as jepsen]
@@ -105,7 +106,9 @@
     :parse-fn (fn [s]
                 (if (string/starts-with? s "~/")
                   (str (System/getProperty "user.home") (subs s 1))
-                  s))]
+                  s))
+    :validate [#(.canRead (io/file %))
+               "Kubeconfig file must exist and be readable"]]
 
    [nil "--lb-internet-facing"
     "if set, expose the ScalarDB Cluster (Envoy) and backend DB LoadBalancers as internet-facing (e.g. on EKS, so a Jepsen control outside the VPC can reach both the cluster and, via the storage API, the backend). Requires cloud-side setup such as tagged public subnets and security group rules. Ignored where the LB provider doesn't use the annotation (e.g. MetalLB)."

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -63,7 +63,16 @@
 (defn- backend-db
   [lb-name]
   (reify cluster-db/ClusterDb
-    (get-lb-service-name [_] lb-name)))
+    (get-lb-service-name [_] lb-name)
+    (get-storage-type [_])
+    (get-contact-points [_])
+    (get-username [_])
+    (get-password [_])
+    (install! [_ _])
+    (configure! [_ _])
+    (start! [_ _])
+    (wipe! [_ _])
+    (create-storage-properties [_ _])))
 
 (defn- annotated-services
   "Runs expose-loadbalancers! against a fixed service list and returns the set of

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -52,7 +52,7 @@
   (testing "prefers the node ExternalIP when it reports one (e.g. EKS/GKE)"
     (with-redefs [k8s/nodes
                   (spy/stub {:items [(node [{:type "ExternalIP" :address "1.2.3.4"}
-                                           {:type "InternalIP" :address "10.0.0.1"}])]})]
+                                            {:type "InternalIP" :address "10.0.0.1"}])]})]
       (is (= "1.2.3.4" (cluster/get-k8s-node-ip {})))))
 
   (testing "falls back to the InternalIP when no ExternalIP (e.g. kind)"

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -1,0 +1,108 @@
+(ns scalardb.db.cluster-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.k8s.core :as k8s]
+            [scalardb.db.cluster :as cluster]
+            [scalardb.db.cluster-db.cluster-db :as cluster-db]
+            [spy.core :as spy]))
+
+(def ^:private find-load-balancer-ip
+  #'cluster/find-load-balancer-ip)
+
+(def ^:private expose-loadbalancers!
+  #'cluster/expose-loadbalancers!)
+
+(defn- lb-service
+  [name ingress]
+  {:metadata {:name name}
+   :spec {:type "LoadBalancer"}
+   :status {:loadBalancer {:ingress [ingress]}}})
+
+(deftest find-load-balancer-ip-test
+  (testing "returns the ingress IP when present"
+    (with-redefs [k8s/services
+                  (spy/stub {:items [(lb-service "postgres" {:ip "1.2.3.4"})]})]
+      (is (= "1.2.3.4" (find-load-balancer-ip {} "postgres")))))
+
+  (testing "falls back to the ingress hostname when there is no IP (e.g. AWS)"
+    (with-redefs [k8s/services
+                  (spy/stub {:items [(lb-service "postgres"
+                                                 {:hostname "abc.elb.amazonaws.com"})]})]
+      (is (= "abc.elb.amazonaws.com" (find-load-balancer-ip {} "postgres")))))
+
+  (testing "matches services by name prefix"
+    (with-redefs [k8s/services
+                  (spy/stub {:items [(lb-service "scalardb-cluster-envoy"
+                                                 {:ip "10.0.0.9"})
+                                     (lb-service "postgres" {:ip "1.2.3.4"})]})]
+      (is (= "10.0.0.9"
+             (find-load-balancer-ip {} "scalardb-cluster-envoy")))))
+
+  (testing "ignores non-LoadBalancer services"
+    (with-redefs [k8s/services
+                  (spy/stub {:items [{:metadata {:name "postgres"}
+                                      :spec {:type "ClusterIP"}
+                                      :status {}}]})]
+      (is (nil? (find-load-balancer-ip {} "postgres"))))))
+
+(defn- node
+  [addresses]
+  {:status {:addresses addresses}})
+
+(deftest get-k8s-node-ip-test
+  (testing "prefers the node ExternalIP when it reports one (e.g. EKS/GKE)"
+    (with-redefs [k8s/nodes
+                  (spy/stub {:items [(node [{:type "ExternalIP" :address "1.2.3.4"}
+                                           {:type "InternalIP" :address "10.0.0.1"}])]})]
+      (is (= "1.2.3.4" (cluster/get-k8s-node-ip {})))))
+
+  (testing "falls back to the InternalIP when no ExternalIP (e.g. kind)"
+    (with-redefs [k8s/nodes
+                  (spy/stub {:items [(node [{:type "InternalIP" :address "10.0.0.1"}])]})]
+      (is (= "10.0.0.1" (cluster/get-k8s-node-ip {}))))))
+
+(defn- backend-db
+  [lb-name]
+  (reify cluster-db/ClusterDb
+    (get-lb-service-name [_] lb-name)))
+
+(defn- annotated-services
+  "Runs expose-loadbalancers! against a fixed service list and returns the set of
+  service names that got the internet-facing annotation."
+  [test lb-name services]
+  (let [annotate (spy/spy)]
+    (with-redefs [k8s/services (spy/stub {:items services})
+                  k8s/kubectl! annotate]
+      (expose-loadbalancers! test (backend-db lb-name)))
+    (->> (spy/calls annotate)
+         ;; each call is (test :annotate :svc <name> :-n <ns> ...)
+         (map #(nth % 3))
+         set)))
+
+(deftest expose-loadbalancers-test
+  (let [services [(lb-service "scalardb-cluster-envoy" {:hostname "envoy.elb"})
+                  (lb-service "postgresql-scalardb-cluster" {:hostname "pg.elb"})
+                  (lb-service "some-leftover-lb" {:hostname "leftover.elb"})
+                  {:metadata {:name "scalardb-cluster"}
+                   :spec {:type "ClusterIP"}
+                   :status {}}]]
+    (testing "annotates only the Envoy and this backend's LoadBalancer"
+      (is (= #{"scalardb-cluster-envoy" "postgresql-scalardb-cluster"}
+             (annotated-services {:name "scalardb-transfer" :lb-internet-facing true}
+                                 "postgresql-scalardb-cluster"
+                                 services))))
+
+    (testing "leaves unrelated/leftover LoadBalancers untouched"
+      (is (not (contains? (annotated-services {:name "scalardb-transfer" :lb-internet-facing true}
+                                              "postgresql-scalardb-cluster"
+                                              services)
+                          "some-leftover-lb"))))
+
+    (testing "annotates only Envoy when the backend has no LoadBalancer (NodePort)"
+      (is (= #{"scalardb-cluster-envoy"}
+             (annotated-services {:name "scalardb-transfer" :lb-internet-facing true}
+                                 nil services))))
+
+    (testing "does nothing unless --lb-internet-facing is set"
+      (is (empty? (annotated-services {:name "scalardb-transfer" :lb-internet-facing false}
+                                      "postgresql-scalardb-cluster"
+                                      services))))))


### PR DESCRIPTION
## Description
I've tested our Jepsen tests on the managed Kubernetes services:
- AWS EKS
- Azure AKS
- Google Cloud GKE

I found that some fixes are required for the `kubeconfig` and the load balancer stuff.
All changes should not affect the local testing.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Add `--kubeconfig` option to specify a k8s config file
- Expose the load balancer services when AWS EKS
- Get the external IP for NodePort

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
