### PR TITLE
Update PingCAP Helm chart URL

### DIFF
--- a/scalardb/src/scalardb/db/cluster_db/tidb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/tidb.clj
@@ -25,7 +25,7 @@
   (get-password [_] TIDB_PASSWORD)
 
   (install! [_ test]
-    (helm/repo-add! test "pingcap" "https://charts.pingcap.org/")
+    (helm/repo-add! test "pingcap" "https://charts.pingcap.com/")
     (k8s/kubectl! test :create :namespace "tidb-admin")
     (k8s/kubectl! test :create :-f TIDB_CRD_URL)
     (helm/install! test {:release TIDB_OPERATOR_NAME


### PR DESCRIPTION
## Description
ScalarDB Cluster tests with TiDB failed in recent days because the chart repository 'https://charts.pingcap.org/' is not reachable.
The Helm chart URL has been updated. [official doc](https://docs.pingcap.com/tidb-in-kubernetes/stable/tidb-toolkit/#configure-the-helm-repo)

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Update the URL

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
