### PR TITLE
Update charts.pingcap helm repo url

### DIFF
--- a/scalardb/src/scalardb/db/cluster_db/tidb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/tidb.clj
@@ -25,7 +25,7 @@
   (get-password [_] TIDB_PASSWORD)
 
   (install! [_ test]
-    (helm/repo-add! test "pingcap" "https://charts.pingcap.org/")
+    (helm/repo-add! test "pingcap" "https://charts.pingcap.com/")
     (k8s/kubectl! test :create :namespace "tidb-admin")
     (k8s/kubectl! test :create :-f TIDB_CRD_URL)
     (helm/install! test {:release TIDB_OPERATOR_NAME


### PR DESCRIPTION
## Description

I have updated  charts.pingcap helm repo url for TiDB tests replaced domain from org to com.
There were an repeating issue with helm repo url which caused test failures for TiDB test for last 5 days.
More details can be found in ticket https://scalar-labs.atlassian.net/browse/DLT-19243.

## Related issues and/or PRs
NA

## Changes made

Updated  charts.pingcap helm repo url for TiDB tests from https://charts.pingcap.org/ to https://charts.pingcap.com/

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

NA
