### PR TITLE
Add file IO nemesis for ScalarDB Cluster test

### DIFF
--- a/.github/workflows/cluster-test.yml
+++ b/.github/workflows/cluster-test.yml
@@ -54,6 +54,7 @@ on:
           - partition
           - packet
           - clock
+          - file-io
       enable_one_phase_commit:
         description: 'Enable one phase commit'
         default: false

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -186,10 +186,14 @@
        (map #(get-in % [:metadata :name]))))
 
 (defn- get-logs
-  "Collect ScalarDB Cluster pod logs into the test's store directory directly."
-  [test]
-  (k8s/collect-logs! test {:selector NODE_SELECTOR
-                           :output-dir (store/path! test "pods")}))
+  "Collect ScalarDB Cluster and backend DB pod logs into the test's store
+  directory directly."
+  [test backend-db]
+  (let [output-dir (store/path! test "pods")]
+    (k8s/collect-logs! test {:selector NODE_SELECTOR :output-dir output-dir})
+    (when (satisfies? cluster-db/ClusterDbLogs backend-db)
+      (k8s/collect-logs! test {:selector (cluster-db/log-selector backend-db)
+                               :output-dir output-dir}))))
 
 (defn- find-load-balancer-ip
   [test prefix]
@@ -299,7 +303,7 @@
     (log-files [_ test _]
       ;; Collect pod logs into store/ ourselves and return [] so jepsen's
       ;; snarf-logs! doesn't try to fetch them over the dummy SSH connection.
-      (get-logs test)
+      (get-logs test backend-db)
       [])))
 
 (defrecord ExtCluster [backend-db]

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -354,11 +354,21 @@
       (if (managed-db-types db-type) (f opts) (f)))
     (throw (ex-info "Unsupported DB for ScalarDB Cluster test" {:db db-type}))))
 
+(defn- nemesis-options
+  [backend-db db-type faults]
+  (if (contains? (set faults) :file-io)
+    (if (satisfies? cluster-db/ClusterDbFileOptions backend-db)
+      {:file-io (cluster-db/file-io-options backend-db)}
+      (throw (ex-info "Backend does not support the file-io nemesis"
+                      {:db db-type})))
+    {}))
+
 (defn gen-db
   [faults admin db-type & [opts]]
   (when (seq admin)
     (warn "The admin operations are ignored: " admin))
   (let [backend-db (cluster-backend-db db-type opts)
         db (ext/extend-db (db backend-db) (->ExtCluster backend-db))
-        nemesis (cm/nemesis-package db 60 faults)]
+        nemesis (cm/nemesis-package db 60 faults
+                                    (nemesis-options backend-db db-type faults))]
     [db nemesis 1]))

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -28,18 +28,6 @@
 (def ^:private ^:const LB_SCHEME_ANNOTATION
   "service.beta.kubernetes.io/aws-load-balancer-scheme")
 
-;; The Chaos Mesh chart defaults to Docker. Without these, chaos-daemon can't
-;; resolve the container PID on a containerd cluster (kind, EKS) and every
-;; fault needing to enter the pod's namespaces (file I/O, network, clock)
-;; fails to apply. Override them for a cluster with another runtime.
-(def ^:private CHAOS_MESH_VALUES
-  {:set {:chaosDaemon.runtime (or (some-> (env :chaos-daemon-runtime)
-                                          not-empty)
-                                  "containerd")
-         :chaosDaemon.socketPath (or (some-> (env :chaos-daemon-socket-path)
-                                             not-empty)
-                                     "/run/containerd/containerd.sock")}})
-
 (def ^:private ^:const CLUSTER_VALUES
   {:envoy {:enabled true
            :service {:type "LoadBalancer"}}
@@ -166,7 +154,7 @@
                            :namespace "default"}))
     (.delete (File. CLUSTER_VALUES_YAML)))
 
-  (cm/setup! test CHAOS_MESH_VALUES)
+  (cm/setup! test {})
 
   ;; Expose the Envoy and backend DB LoadBalancers to outside the cloud network
   ;; when requested (e.g. a Jepsen control running outside the VPC on EKS).

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -185,15 +185,27 @@
        (filter #(= "Running" (get-in % [:status :phase])))
        (map #(get-in % [:metadata :name]))))
 
+(defn- collect-logs!
+  [test opts]
+  (try
+    (k8s/collect-logs! test opts)
+    (catch Exception e
+      (warn e "Failed to collect pod logs:" opts))))
+
 (defn- get-logs
-  "Collect ScalarDB Cluster and backend DB pod logs into the test's store
-  directory directly."
+  "Collect ScalarDB Cluster, backend DB and Chaos Mesh pod logs into the test's
+  store directory directly."
   [test backend-db]
   (let [output-dir (store/path! test "pods")]
-    (k8s/collect-logs! test {:selector NODE_SELECTOR :output-dir output-dir})
+    (collect-logs! test {:selector NODE_SELECTOR :output-dir output-dir})
     (when (satisfies? cluster-db/ClusterDbLogs backend-db)
-      (k8s/collect-logs! test {:selector (cluster-db/log-selector backend-db)
-                               :output-dir output-dir}))))
+      (collect-logs! test {:selector (cluster-db/log-selector backend-db)
+                           :output-dir output-dir}))
+    ;; Chaos Mesh's own logs tell whether a fault was really injected: the
+    ;; controller manager reconciles the experiment and the chaos daemons
+    ;; apply it on each node.
+    (collect-logs! test {:namespace cm/default-namespace
+                         :output-dir (store/path! test "pods" "chaos-mesh")})))
 
 (defn- find-load-balancer-ip
   [test prefix]

--- a/scalardb/src/scalardb/db/cluster.clj
+++ b/scalardb/src/scalardb/db/cluster.clj
@@ -28,6 +28,18 @@
 (def ^:private ^:const LB_SCHEME_ANNOTATION
   "service.beta.kubernetes.io/aws-load-balancer-scheme")
 
+;; The Chaos Mesh chart defaults to Docker. Without these, chaos-daemon can't
+;; resolve the container PID on a containerd cluster (kind, EKS) and every
+;; fault needing to enter the pod's namespaces (file I/O, network, clock)
+;; fails to apply. Override them for a cluster with another runtime.
+(def ^:private CHAOS_MESH_VALUES
+  {:set {:chaosDaemon.runtime (or (some-> (env :chaos-daemon-runtime)
+                                          not-empty)
+                                  "containerd")
+         :chaosDaemon.socketPath (or (some-> (env :chaos-daemon-socket-path)
+                                             not-empty)
+                                     "/run/containerd/containerd.sock")}})
+
 (def ^:private ^:const CLUSTER_VALUES
   {:envoy {:enabled true
            :service {:type "LoadBalancer"}}
@@ -154,7 +166,7 @@
                            :namespace "default"}))
     (.delete (File. CLUSTER_VALUES_YAML)))
 
-  (cm/setup! test {})
+  (cm/setup! test CHAOS_MESH_VALUES)
 
   ;; Expose the Envoy and backend DB LoadBalancers to outside the cloud network
   ;; when requested (e.g. a Jepsen control running outside the VPC on EKS).
@@ -371,6 +383,10 @@
     (throw (ex-info "Unsupported DB for ScalarDB Cluster test" {:db db-type}))))
 
 (defn- nemesis-options
+  "Note: the file-io nemesis needs amd64 nodes. Chaos Mesh injects IOChaos with
+  toda, and the binary shipped even in the arm64 chaos-daemon image is x86-64,
+  so it dies under emulation and no fault is ever applied (the chaos controller
+  manager logs it). Run this fault on an amd64 cluster."
   [backend-db db-type faults]
   (if (contains? (set faults) :file-io)
     (if (satisfies? cluster-db/ClusterDbFileOptions backend-db)

--- a/scalardb/src/scalardb/db/cluster_db/alloydb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/alloydb.clj
@@ -5,7 +5,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.io File)
            (java.util Properties)))
 
@@ -103,6 +104,10 @@
      :file-path "/mnt/disks/pgsql/data/**/*"
      :pod-selector {"alloydbomni.internal.dbadmin.goog/dbcluster" ALLOYDB_NAME
                     "alloydbomni.internal.dbadmin.goog/task-type" "database"}
-     :container-names ["database"]}))
+     :container-names ["database"]})
+
+  ClusterDbLogs
+  (log-selector [_]
+    {"alloydbomni.internal.dbadmin.goog/dbcluster" ALLOYDB_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbAlloyDb))

--- a/scalardb/src/scalardb/db/cluster_db/alloydb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/alloydb.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.core :as k8s]
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.io File)
            (java.util Properties)))
 
@@ -94,6 +95,14 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:postgresql://" ip ":5432/postgres"))
         (.setProperty "scalar.db.username" ALLOYDB_USER)
-        (.setProperty "scalar.db.password" ALLOYDB_PASSWORD)))))
+        (.setProperty "scalar.db.password" ALLOYDB_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/mnt/disks/pgsql"
+     :file-path "/mnt/disks/pgsql/data/**/*"
+     :pod-selector {"alloydbomni.internal.dbadmin.goog/dbcluster" ALLOYDB_NAME
+                    "alloydbomni.internal.dbadmin.goog/task-type" "database"}
+     :container-names ["database"]}))
 
 (defn gen-cluster-db [] (->ClusterDbAlloyDb))

--- a/scalardb/src/scalardb/db/cluster_db/cassandra.clj
+++ b/scalardb/src/scalardb/db/cluster_db/cassandra.clj
@@ -5,6 +5,7 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions
                                                        ClusterDbTableOptions]])
   (:import (java.util Properties)))
 
@@ -100,6 +101,17 @@
         (.setProperty "scalar.db.contact_points" ip)
         (.setProperty "scalar.db.username" CASSANDRA_USER)
         (.setProperty "scalar.db.password" CASSANDRA_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    ;; The persistent volume is mounted at /bitnami/cassandra and holds the
+    ;; SSTables, the commit log, the hints and the saved caches. Fault the
+    ;; whole volume so a write can't reach any of them.
+    {:volume-path "/bitnami/cassandra"
+     :file-path "/bitnami/cassandra/**/*"
+     :pod-selector {"app.kubernetes.io/instance" CASSANDRA_NAME
+                    "app.kubernetes.io/name" "cassandra"}
+     :container-names ["cassandra"]})
 
   ClusterDbTableOptions
   (create-table-opts [_ _]

--- a/scalardb/src/scalardb/db/cluster_db/cassandra.clj
+++ b/scalardb/src/scalardb/db/cluster_db/cassandra.clj
@@ -57,6 +57,8 @@
             :dbUser.password CASSANDRA_PASSWORD
             :replicaCount CASSANDRA_REPLICA_COUNT
             :persistence.enabled true
+            ;; See the comment in the PostgreSQL backend.
+            :containerSecurityContext.readOnlyRootFilesystem false
             :service.type "LoadBalancer"
             :jvm.maxHeapSize "1024M"
             :jvm.newHeapSize "256M"

--- a/scalardb/src/scalardb/db/cluster_db/cassandra.clj
+++ b/scalardb/src/scalardb/db/cluster_db/cassandra.clj
@@ -6,6 +6,7 @@
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
                                                        ClusterDbFileOptions
+                                                       ClusterDbLogs
                                                        ClusterDbTableOptions]])
   (:import (java.util Properties)))
 
@@ -112,6 +113,9 @@
      :pod-selector {"app.kubernetes.io/instance" CASSANDRA_NAME
                     "app.kubernetes.io/name" "cassandra"}
      :container-names ["cassandra"]})
+
+  ClusterDbLogs
+  (log-selector [_] {"app.kubernetes.io/instance" CASSANDRA_NAME})
 
   ClusterDbTableOptions
   (create-table-opts [_ _]

--- a/scalardb/src/scalardb/db/cluster_db/cluster_db.clj
+++ b/scalardb/src/scalardb/db/cluster_db/cluster_db.clj
@@ -14,3 +14,7 @@
 
 (defprotocol ClusterDbTableOptions
   (create-table-opts [this test]))
+
+(defprotocol ClusterDbFileOptions
+  (file-io-options [this]
+    "Returns the Chaos Mesh file I/O configuration for this backend."))

--- a/scalardb/src/scalardb/db/cluster_db/cluster_db.clj
+++ b/scalardb/src/scalardb/db/cluster_db/cluster_db.clj
@@ -18,3 +18,9 @@
 (defprotocol ClusterDbFileOptions
   (file-io-options [this]
     "Returns the Chaos Mesh file I/O configuration for this backend."))
+
+(defprotocol ClusterDbLogs
+  (log-selector [this]
+    "Returns a label selector matching this backend's database pods.
+    Backends implement this to have their pod logs collected into the store.
+    Externally-provisioned backends have no pods and don't implement it."))

--- a/scalardb/src/scalardb/db/cluster_db/db2.clj
+++ b/scalardb/src/scalardb/db/cluster_db/db2.clj
@@ -4,7 +4,8 @@
             [scalardb.core :as scalar]
             [scalardb.db.cluster :refer [get-k8s-node-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const DB2_NAME "db2-scalardb-cluster")
@@ -64,6 +65,9 @@
     {:volume-path "/database"
      :file-path "/database/**/*"
      :pod-selector {:app DB2_NAME}
-     :container-names ["db2"]}))
+     :container-names ["db2"]})
+
+  ClusterDbLogs
+  (log-selector [_] {:app DB2_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbDb2))

--- a/scalardb/src/scalardb/db/cluster_db/db2.clj
+++ b/scalardb/src/scalardb/db/cluster_db/db2.clj
@@ -3,7 +3,8 @@
             [jepsen.k8s.core :as k8s]
             [scalardb.core :as scalar]
             [scalardb.db.cluster :refer [get-k8s-node-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const DB2_NAME "db2-scalardb-cluster")
@@ -56,6 +57,13 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:db2://" ip ":31500/" scalar/KEYSPACE))
         (.setProperty "scalar.db.username" DB2_USER)
-        (.setProperty "scalar.db.password" DB2_PASSWORD)))))
+        (.setProperty "scalar.db.password" DB2_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/database"
+     :file-path "/database/**/*"
+     :pod-selector {:app DB2_NAME}
+     :container-names ["db2"]}))
 
 (defn gen-cluster-db [] (->ClusterDbDb2))

--- a/scalardb/src/scalardb/db/cluster_db/mariadb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mariadb.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.core :as scalar]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const MARIADB_NAME "mariadb-scalardb-cluster")
@@ -59,6 +60,14 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:mariadb://" ip ":3306/" scalar/KEYSPACE))
         (.setProperty "scalar.db.username" MARIADB_USER)
-        (.setProperty "scalar.db.password" MARIADB_PASSWORD)))))
+        (.setProperty "scalar.db.password" MARIADB_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/bitnami/mariadb"
+     :file-path "/bitnami/mariadb/data/**/*"
+     :pod-selector {"app.kubernetes.io/instance" MARIADB_NAME
+                    "app.kubernetes.io/component" "primary"}
+     :container-names ["mariadb"]}))
 
 (defn gen-cluster-db [] (->ClusterDbMariaDb))

--- a/scalardb/src/scalardb/db/cluster_db/mariadb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mariadb.clj
@@ -39,6 +39,8 @@
                          :set {:auth.rootPassword MARIADB_PASSWORD
                                :auth.database scalar/KEYSPACE
                                :primary.persistence.enabled true
+                               ;; See the comment in the PostgreSQL backend.
+                               :primary.containerSecurityContext.readOnlyRootFilesystem false
                                :primary.service.type "LoadBalancer"
                                :image.repository "bitnamilegacy/mariadb"
                                :volumePermissions.image.repository "bitnamilegacy/os-shell"

--- a/scalardb/src/scalardb/db/cluster_db/mariadb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mariadb.clj
@@ -5,7 +5,8 @@
             [scalardb.core :as scalar]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const MARIADB_NAME "mariadb-scalardb-cluster")
@@ -68,6 +69,9 @@
      :file-path "/bitnami/mariadb/data/**/*"
      :pod-selector {"app.kubernetes.io/instance" MARIADB_NAME
                     "app.kubernetes.io/component" "primary"}
-     :container-names ["mariadb"]}))
+     :container-names ["mariadb"]})
+
+  ClusterDbLogs
+  (log-selector [_] {"app.kubernetes.io/instance" MARIADB_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbMariaDb))

--- a/scalardb/src/scalardb/db/cluster_db/mysql.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mysql.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.core :as scalar]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const MYSQL_NAME "mysql-scalardb-cluster")
@@ -59,6 +60,14 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:mysql://" ip ":3306/" scalar/KEYSPACE))
         (.setProperty "scalar.db.username" MYSQL_USER)
-        (.setProperty "scalar.db.password" MYSQL_PASSWORD)))))
+        (.setProperty "scalar.db.password" MYSQL_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/bitnami/mysql"
+     :file-path "/bitnami/mysql/data/**/*"
+     :pod-selector {"app.kubernetes.io/instance" MYSQL_NAME
+                    "app.kubernetes.io/component" "primary"}
+     :container-names ["mysql"]}))
 
 (defn gen-cluster-db [] (->ClusterDbMySql))

--- a/scalardb/src/scalardb/db/cluster_db/mysql.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mysql.clj
@@ -39,6 +39,8 @@
                          :set {:auth.rootPassword MYSQL_PASSWORD
                                :auth.database scalar/KEYSPACE
                                :primary.persistence.enabled true
+                               ;; See the comment in the PostgreSQL backend.
+                               :primary.containerSecurityContext.readOnlyRootFilesystem false
                                :primary.service.type "LoadBalancer"
                                :image.repository "bitnamilegacy/mysql"
                                :volumePermissions.image.repository "bitnamilegacy/os-shell"

--- a/scalardb/src/scalardb/db/cluster_db/mysql.clj
+++ b/scalardb/src/scalardb/db/cluster_db/mysql.clj
@@ -5,7 +5,8 @@
             [scalardb.core :as scalar]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const MYSQL_NAME "mysql-scalardb-cluster")
@@ -68,6 +69,9 @@
      :file-path "/bitnami/mysql/data/**/*"
      :pod-selector {"app.kubernetes.io/instance" MYSQL_NAME
                     "app.kubernetes.io/component" "primary"}
-     :container-names ["mysql"]}))
+     :container-names ["mysql"]})
+
+  ClusterDbLogs
+  (log-selector [_] {"app.kubernetes.io/instance" MYSQL_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbMySql))

--- a/scalardb/src/scalardb/db/cluster_db/oracle.clj
+++ b/scalardb/src/scalardb/db/cluster_db/oracle.clj
@@ -2,7 +2,8 @@
   (:require [clojure.tools.logging :refer [warn]]
             [jepsen.k8s.core :as k8s]
             [scalardb.db.cluster :refer [get-k8s-node-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const ORACLE_NAME "oracle-scalardb-cluster")
@@ -54,6 +55,13 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:oracle:thin:@" ip ":31521/FREEPDB1"))
         (.setProperty "scalar.db.username" ORACLE_USER)
-        (.setProperty "scalar.db.password" ORACLE_PASSWORD)))))
+        (.setProperty "scalar.db.password" ORACLE_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/opt/oracle/oradata"
+     :file-path "/opt/oracle/oradata/**/*"
+     :pod-selector {:app ORACLE_NAME}
+     :container-names ["oracle"]}))
 
 (defn gen-cluster-db [] (->ClusterDbOracle))

--- a/scalardb/src/scalardb/db/cluster_db/oracle.clj
+++ b/scalardb/src/scalardb/db/cluster_db/oracle.clj
@@ -3,7 +3,8 @@
             [jepsen.k8s.core :as k8s]
             [scalardb.db.cluster :refer [get-k8s-node-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const ORACLE_NAME "oracle-scalardb-cluster")
@@ -62,6 +63,9 @@
     {:volume-path "/opt/oracle/oradata"
      :file-path "/opt/oracle/oradata/**/*"
      :pod-selector {:app ORACLE_NAME}
-     :container-names ["oracle"]}))
+     :container-names ["oracle"]})
+
+  ClusterDbLogs
+  (log-selector [_] {:app ORACLE_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbOracle))

--- a/scalardb/src/scalardb/db/cluster_db/postgres.clj
+++ b/scalardb/src/scalardb/db/cluster_db/postgres.clj
@@ -3,7 +3,8 @@
             [jepsen.k8s.core :as k8s]
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const POSTGRESQL_NAME "postgresql-scalardb-cluster")
@@ -59,6 +60,14 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:postgresql://" ip ":5432/postgres"))
         (.setProperty "scalar.db.username" POSTGRESQL_USER)
-        (.setProperty "scalar.db.password" POSTGRESQL_PASSWORD)))))
+        (.setProperty "scalar.db.password" POSTGRESQL_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/bitnami/postgresql"
+     :file-path "/bitnami/postgresql/data/**/*"
+     :pod-selector {"app.kubernetes.io/instance" POSTGRESQL_NAME
+                    "app.kubernetes.io/component" "primary"}
+     :container-names ["postgresql"]}))
 
 (defn gen-cluster-db [] (->ClusterDbPostgres))

--- a/scalardb/src/scalardb/db/cluster_db/postgres.clj
+++ b/scalardb/src/scalardb/db/cluster_db/postgres.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const POSTGRESQL_NAME "postgresql-scalardb-cluster")
@@ -68,6 +69,9 @@
      :file-path "/bitnami/postgresql/data/**/*"
      :pod-selector {"app.kubernetes.io/instance" POSTGRESQL_NAME
                     "app.kubernetes.io/component" "primary"}
-     :container-names ["postgresql"]}))
+     :container-names ["postgresql"]})
+
+  ClusterDbLogs
+  (log-selector [_] {"app.kubernetes.io/instance" POSTGRESQL_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbPostgres))

--- a/scalardb/src/scalardb/db/cluster_db/postgres.clj
+++ b/scalardb/src/scalardb/db/cluster_db/postgres.clj
@@ -36,6 +36,10 @@
                          :version "16.7.0"
                          :set {:auth.postgresPassword POSTGRESQL_PASSWORD
                                :primary.persistence.enabled true
+                               ;; toda, which Chaos Mesh injects IOChaos with,
+                               ;; sets up its mount inside the container and
+                               ;; can't start on a read-only root filesystem.
+                               :primary.containerSecurityContext.readOnlyRootFilesystem false
                                :service.type "LoadBalancer"
                                :primary.service.type "LoadBalancer"
                                :image.repository "bitnamilegacy/postgresql"

--- a/scalardb/src/scalardb/db/cluster_db/sqlserver.clj
+++ b/scalardb/src/scalardb/db/cluster_db/sqlserver.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const SQLSERVER_NAME "sqlserver-scalardb-cluster")
@@ -69,6 +70,9 @@
      :file-path "/var/opt/mssql/**/*"
      :pod-selector {:app (str SQLSERVER_NAME "-mssqlserver-2022")
                     :release SQLSERVER_NAME}
-     :container-names ["mssqlserver-2022"]}))
+     :container-names ["mssqlserver-2022"]})
+
+  ClusterDbLogs
+  (log-selector [_] {:release SQLSERVER_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbSqlServer))

--- a/scalardb/src/scalardb/db/cluster_db/sqlserver.clj
+++ b/scalardb/src/scalardb/db/cluster_db/sqlserver.clj
@@ -3,7 +3,8 @@
             [jepsen.k8s.core :as k8s]
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const SQLSERVER_NAME "sqlserver-scalardb-cluster")
@@ -60,6 +61,14 @@
                            ip
                            ":1433;encrypt=true;trustServerCertificate=true"))
         (.setProperty "scalar.db.username" SQLSERVER_USER)
-        (.setProperty "scalar.db.password" SQLSERVER_PASSWORD)))))
+        (.setProperty "scalar.db.password" SQLSERVER_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/var/opt/mssql"
+     :file-path "/var/opt/mssql/**/*"
+     :pod-selector {:app (str SQLSERVER_NAME "-mssqlserver-2022")
+                    :release SQLSERVER_NAME}
+     :container-names ["mssqlserver-2022"]}))
 
 (defn gen-cluster-db [] (->ClusterDbSqlServer))

--- a/scalardb/src/scalardb/db/cluster_db/tidb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/tidb.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const TIDB_NAME "tidb-scalardb-cluster-tidb")
@@ -74,6 +75,10 @@
      :file-path "/var/lib/tikv/**/*"
      :pod-selector {"app.kubernetes.io/instance" "tidb-scalardb-cluster"
                     "app.kubernetes.io/component" "tikv"}
-     :container-names ["tikv"]}))
+     :container-names ["tikv"]})
+
+  ClusterDbLogs
+  ;; Covers the PD, TiKV and TiDB pods. The operator lives in tidb-admin.
+  (log-selector [_] {"app.kubernetes.io/instance" "tidb-scalardb-cluster"}))
 
 (defn gen-cluster-db [] (->ClusterDbTiDb))

--- a/scalardb/src/scalardb/db/cluster_db/tidb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/tidb.clj
@@ -3,7 +3,8 @@
             [jepsen.k8s.core :as k8s]
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const TIDB_NAME "tidb-scalardb-cluster-tidb")
@@ -65,6 +66,14 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:mysql://" ip ":4000/mysql"))
         (.setProperty "scalar.db.username" TIDB_USER)
-        (.setProperty "scalar.db.password" TIDB_PASSWORD)))))
+        (.setProperty "scalar.db.password" TIDB_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/var/lib/tikv"
+     :file-path "/var/lib/tikv/**/*"
+     :pod-selector {"app.kubernetes.io/instance" "tidb-scalardb-cluster"
+                    "app.kubernetes.io/component" "tikv"}
+     :container-names ["tikv"]}))
 
 (defn gen-cluster-db [] (->ClusterDbTiDb))

--- a/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
@@ -4,7 +4,8 @@
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
             [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
-                                                       ClusterDbFileOptions]])
+                                                       ClusterDbFileOptions
+                                                       ClusterDbLogs]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const YUGABYTEDB_NAME "yugabytedb-scalardb-cluster")
@@ -75,6 +76,10 @@
      :file-path "/mnt/disk0/**/*"
      :pod-selector {:app "yb-tserver"
                     :release YUGABYTEDB_NAME}
-     :container-names ["yb-tserver"]}))
+     :container-names ["yb-tserver"]})
+
+  ClusterDbLogs
+  ;; Covers both the yb-master and yb-tserver pods.
+  (log-selector [_] {:release YUGABYTEDB_NAME}))
 
 (defn gen-cluster-db [] (->ClusterDbYugabyteDb))

--- a/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
+++ b/scalardb/src/scalardb/db/cluster_db/yugabytedb.clj
@@ -3,7 +3,8 @@
             [jepsen.k8s.core :as k8s]
             [jepsen.k8s.helm :as helm]
             [scalardb.db.cluster :refer [get-load-balancer-ip WIPE_TIMEOUT]]
-            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb]])
+            [scalardb.db.cluster-db.cluster-db :refer [ClusterDb
+                                                       ClusterDbFileOptions]])
   (:import (java.util Properties)))
 
 (def ^:private ^:const YUGABYTEDB_NAME "yugabytedb-scalardb-cluster")
@@ -66,6 +67,14 @@
         (.setProperty "scalar.db.contact_points"
                       (str "jdbc:yugabytedb://" ip ":5433/yugabyte"))
         (.setProperty "scalar.db.username" YUGABYTEDB_USER)
-        (.setProperty "scalar.db.password" YUGABYTEDB_PASSWORD)))))
+        (.setProperty "scalar.db.password" YUGABYTEDB_PASSWORD))))
+
+  ClusterDbFileOptions
+  (file-io-options [_]
+    {:volume-path "/mnt/disk0"
+     :file-path "/mnt/disk0/**/*"
+     :pod-selector {:app "yb-tserver"
+                    :release YUGABYTEDB_NAME}
+     :container-names ["yb-tserver"]}))
 
 (defn gen-cluster-db [] (->ClusterDbYugabyteDb))

--- a/scalardb/src/scalardb/db/postgres.clj
+++ b/scalardb/src/scalardb/db/postgres.clj
@@ -164,10 +164,20 @@
                (ext/set-common-properties test)))))
   (create-storage-properties [this test] (ext/create-properties this test)))
 
+(def ^:private SUPPORTED_FAULTS
+  "Faults `jn/nemesis-package` builds a generator for with the options below.
+  Anything else (e.g. `:file-io`, which needs Chaos Mesh) would leave the test
+  with no fault injection at all instead of failing."
+  #{:partition :packet :clock :kill :pause})
+
 (defn gen-db
   [faults admin & _]
   (when (seq admin)
     (warn "The admin operations are ignored: " admin))
+  (when-not (every? SUPPORTED_FAULTS faults)
+    (throw
+     (ex-info
+      (str "Invalid nemesis for PostgreSQL: " faults) {})))
   [(ext/extend-db (db) (->ExtPostgres))
    (jn/nemesis-package
     {:db db

--- a/scalardb/src/scalardb/runner.clj
+++ b/scalardb/src/scalardb/runner.clj
@@ -63,7 +63,8 @@
    "packet"    [:packet]
    "clock"     [:clock]
    "crash"     [:kill]
-   "pause"     [:pause]})
+   "pause"     [:pause]
+   "file-io"   [:file-io]})
 
 (def test-opt-spec
   [(cli/repeated-opt nil "--db NAME" "DB(s) on which the test is run"

--- a/scalardb/test/scalardb/db/cluster_db/file_options_test.clj
+++ b/scalardb/test/scalardb/db/cluster_db/file_options_test.clj
@@ -1,5 +1,6 @@
 (ns scalardb.db.cluster-db.file-options-test
   (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.k8s.chaos-mesh.file-io :as file-io]
             [scalardb.db.cluster-db.alloydb :as alloydb]
             [scalardb.db.cluster-db.cassandra :as cassandra]
             [scalardb.db.cluster-db.cluster-db :as cluster-db]
@@ -91,4 +92,9 @@
              :container-names ["db2"]}]]]
     (testing (name backend-name)
       (is (satisfies? cluster-db/ClusterDbFileOptions backend))
-      (is (= expected (cluster-db/file-io-options backend))))))
+      (is (= expected (cluster-db/file-io-options backend)))
+      ;; The real validator checks path containment, the container names and
+      ;; the pod selector, so a typo fails here instead of after a full
+      ;; cluster provision in a live run.
+      (is (map? (#'file-io/validate-config
+                 (cluster-db/file-io-options backend)))))))

--- a/scalardb/test/scalardb/db/cluster_db/file_options_test.clj
+++ b/scalardb/test/scalardb/db/cluster_db/file_options_test.clj
@@ -1,0 +1,94 @@
+(ns scalardb.db.cluster-db.file-options-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [scalardb.db.cluster-db.alloydb :as alloydb]
+            [scalardb.db.cluster-db.cassandra :as cassandra]
+            [scalardb.db.cluster-db.cluster-db :as cluster-db]
+            [scalardb.db.cluster-db.db2 :as db2]
+            [scalardb.db.cluster-db.mariadb :as mariadb]
+            [scalardb.db.cluster-db.mysql :as mysql]
+            [scalardb.db.cluster-db.oracle :as oracle]
+            [scalardb.db.cluster-db.postgres :as postgres]
+            [scalardb.db.cluster-db.sqlserver :as sqlserver]
+            [scalardb.db.cluster-db.tidb :as tidb]
+            [scalardb.db.cluster-db.yugabytedb :as yugabytedb]))
+
+(deftest file-io-options-test
+  (doseq [[backend-name backend expected]
+          [[:cassandra
+            (cassandra/gen-cluster-db)
+            {:volume-path "/bitnami/cassandra"
+             :file-path "/bitnami/cassandra/**/*"
+             :pod-selector {"app.kubernetes.io/instance"
+                            "cassandra-scalardb-cluster"
+                            "app.kubernetes.io/name" "cassandra"}
+             :container-names ["cassandra"]}]
+           [:postgres
+            (postgres/gen-cluster-db)
+            {:volume-path "/bitnami/postgresql"
+             :file-path "/bitnami/postgresql/data/**/*"
+             :pod-selector {"app.kubernetes.io/instance"
+                            "postgresql-scalardb-cluster"
+                            "app.kubernetes.io/component" "primary"}
+             :container-names ["postgresql"]}]
+           [:alloydb
+            (alloydb/gen-cluster-db)
+            {:volume-path "/mnt/disks/pgsql"
+             :file-path "/mnt/disks/pgsql/data/**/*"
+             :pod-selector
+             {"alloydbomni.internal.dbadmin.goog/dbcluster"
+              "alloydb-scalardb-cluster"
+              "alloydbomni.internal.dbadmin.goog/task-type" "database"}
+             :container-names ["database"]}]
+           [:yugabytedb
+            (yugabytedb/gen-cluster-db)
+            {:volume-path "/mnt/disk0"
+             :file-path "/mnt/disk0/**/*"
+             :pod-selector {:app "yb-tserver"
+                            :release "yugabytedb-scalardb-cluster"}
+             :container-names ["yb-tserver"]}]
+           [:mysql
+            (mysql/gen-cluster-db)
+            {:volume-path "/bitnami/mysql"
+             :file-path "/bitnami/mysql/data/**/*"
+             :pod-selector {"app.kubernetes.io/instance"
+                            "mysql-scalardb-cluster"
+                            "app.kubernetes.io/component" "primary"}
+             :container-names ["mysql"]}]
+           [:mariadb
+            (mariadb/gen-cluster-db)
+            {:volume-path "/bitnami/mariadb"
+             :file-path "/bitnami/mariadb/data/**/*"
+             :pod-selector {"app.kubernetes.io/instance"
+                            "mariadb-scalardb-cluster"
+                            "app.kubernetes.io/component" "primary"}
+             :container-names ["mariadb"]}]
+           [:tidb
+            (tidb/gen-cluster-db)
+            {:volume-path "/var/lib/tikv"
+             :file-path "/var/lib/tikv/**/*"
+             :pod-selector {"app.kubernetes.io/instance"
+                            "tidb-scalardb-cluster"
+                            "app.kubernetes.io/component" "tikv"}
+             :container-names ["tikv"]}]
+           [:sqlserver
+            (sqlserver/gen-cluster-db)
+            {:volume-path "/var/opt/mssql"
+             :file-path "/var/opt/mssql/**/*"
+             :pod-selector {:app "sqlserver-scalardb-cluster-mssqlserver-2022"
+                            :release "sqlserver-scalardb-cluster"}
+             :container-names ["mssqlserver-2022"]}]
+           [:oracle
+            (oracle/gen-cluster-db)
+            {:volume-path "/opt/oracle/oradata"
+             :file-path "/opt/oracle/oradata/**/*"
+             :pod-selector {:app "oracle-scalardb-cluster"}
+             :container-names ["oracle"]}]
+           [:db2
+            (db2/gen-cluster-db)
+            {:volume-path "/database"
+             :file-path "/database/**/*"
+             :pod-selector {:app "db2-scalardb-cluster"}
+             :container-names ["db2"]}]]]
+    (testing (name backend-name)
+      (is (satisfies? cluster-db/ClusterDbFileOptions backend))
+      (is (= expected (cluster-db/file-io-options backend))))))

--- a/scalardb/test/scalardb/db/cluster_db/log_selector_test.clj
+++ b/scalardb/test/scalardb/db/cluster_db/log_selector_test.clj
@@ -1,0 +1,59 @@
+(ns scalardb.db.cluster-db.log-selector-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.k8s.core :as k8s]
+            [scalardb.db.cluster-db.alloydb :as alloydb]
+            [scalardb.db.cluster-db.cassandra :as cassandra]
+            [scalardb.db.cluster-db.cluster-db :as cluster-db]
+            [scalardb.db.cluster-db.db2 :as db2]
+            [scalardb.db.cluster-db.managed :as managed]
+            [scalardb.db.cluster-db.mariadb :as mariadb]
+            [scalardb.db.cluster-db.mysql :as mysql]
+            [scalardb.db.cluster-db.oracle :as oracle]
+            [scalardb.db.cluster-db.postgres :as postgres]
+            [scalardb.db.cluster-db.sqlserver :as sqlserver]
+            [scalardb.db.cluster-db.tidb :as tidb]
+            [scalardb.db.cluster-db.yugabytedb :as yugabytedb]))
+
+(deftest log-selector-test
+  (doseq [[backend-name backend expected]
+          [[:cassandra
+            (cassandra/gen-cluster-db)
+            {"app.kubernetes.io/instance" "cassandra-scalardb-cluster"}]
+           [:postgres
+            (postgres/gen-cluster-db)
+            {"app.kubernetes.io/instance" "postgresql-scalardb-cluster"}]
+           [:alloydb
+            (alloydb/gen-cluster-db)
+            {"alloydbomni.internal.dbadmin.goog/dbcluster"
+             "alloydb-scalardb-cluster"}]
+           [:yugabytedb
+            (yugabytedb/gen-cluster-db)
+            {:release "yugabytedb-scalardb-cluster"}]
+           [:mysql
+            (mysql/gen-cluster-db)
+            {"app.kubernetes.io/instance" "mysql-scalardb-cluster"}]
+           [:mariadb
+            (mariadb/gen-cluster-db)
+            {"app.kubernetes.io/instance" "mariadb-scalardb-cluster"}]
+           [:tidb
+            (tidb/gen-cluster-db)
+            {"app.kubernetes.io/instance" "tidb-scalardb-cluster"}]
+           [:sqlserver
+            (sqlserver/gen-cluster-db)
+            {:release "sqlserver-scalardb-cluster"}]
+           [:oracle
+            (oracle/gen-cluster-db)
+            {:app "oracle-scalardb-cluster"}]
+           [:db2
+            (db2/gen-cluster-db)
+            {:app "db2-scalardb-cluster"}]]]
+    (testing (name backend-name)
+      (is (satisfies? cluster-db/ClusterDbLogs backend))
+      (is (= expected (cluster-db/log-selector backend)))
+      (testing "is a valid label selector"
+        (is (string? (k8s/label-selector (cluster-db/log-selector backend))))))))
+
+(deftest managed-db-has-no-logs-test
+  (testing "an externally-provisioned backend has no pods to collect"
+    (is (not (satisfies? cluster-db/ClusterDbLogs
+                         (managed/->ClusterDbManaged {}))))))

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -166,6 +166,14 @@
                   k8s/collect-logs! (fn [_ _] (throw (ex-info "boom" {})))]
       (is (nil? (#'cluster/get-logs {} backend-with-logs))))))
 
+(deftest chaos-mesh-values-test
+  (testing "chaos-daemon uses the container runtime of the test cluster"
+    ;; The chart defaults to Docker, which makes every fault that enters the
+    ;; pod's namespaces fail to apply on a containerd cluster.
+    (is (= {:set {:chaosDaemon.runtime "containerd"
+                  :chaosDaemon.socketPath "/run/containerd/containerd.sock"}}
+           @#'cluster/CHAOS_MESH_VALUES))))
+
 (deftest nemesis-options-test
   (testing "adds backend-specific options for the file-io nemesis"
     (is (= {:file-io file-io-options}

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -162,9 +162,18 @@
            (collected-logs (Object.)))))
 
   (testing "keeps collecting when one of the requests fails"
-    (with-redefs [store/path! (fn [_ & dirs] (str/join "/" dirs))
-                  k8s/collect-logs! (fn [_ _] (throw (ex-info "boom" {})))]
-      (is (nil? (#'cluster/get-logs {} backend-with-logs))))))
+    (let [requests (atom [])]
+      (with-redefs [store/path! (fn [_ & dirs] (str/join "/" dirs))
+                    k8s/collect-logs!
+                    (fn [_ opts]
+                      (swap! requests conj opts)
+                      (when (= {:app "database"} (:selector opts))
+                        (throw (ex-info "boom" {}))))]
+        (#'cluster/get-logs {} backend-with-logs))
+      (is (= [cluster-logs
+              {:selector {:app "database"} :output-dir "pods"}
+              chaos-mesh-logs]
+             @requests)))))
 
 (deftest nemesis-options-test
   (testing "adds backend-specific options for the file-io nemesis"

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -166,14 +166,6 @@
                   k8s/collect-logs! (fn [_ _] (throw (ex-info "boom" {})))]
       (is (nil? (#'cluster/get-logs {} backend-with-logs))))))
 
-(deftest chaos-mesh-values-test
-  (testing "chaos-daemon uses the container runtime of the test cluster"
-    ;; The chart defaults to Docker, which makes every fault that enters the
-    ;; pod's namespaces fail to apply on a containerd cluster.
-    (is (= {:set {:chaosDaemon.runtime "containerd"
-                  :chaosDaemon.socketPath "/run/containerd/containerd.sock"}}
-           @#'cluster/CHAOS_MESH_VALUES))))
-
 (deftest nemesis-options-test
   (testing "adds backend-specific options for the file-io nemesis"
     (is (= {:file-io file-io-options}

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -1,5 +1,6 @@
 (ns scalardb.db.cluster-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [jepsen.k8s.core :as k8s]
             [jepsen.store :as store]
             [scalardb.db.cluster :as cluster]
@@ -133,27 +134,37 @@
     cluster-db/ClusterDbLogs
     (log-selector [_] {:app "database"})))
 
-(defn- collected-selectors
-  "Runs get-logs with a mocked k8s, returning the selectors it collected."
+(defn- collected-logs
+  "Runs get-logs with a mocked k8s, returning the log requests it made."
   [backend-db]
-  (let [selectors (atom [])]
-    (with-redefs [store/path! (fn [_ dir] dir)
+  (let [requests (atom [])]
+    (with-redefs [store/path! (fn [_ & dirs] (str/join "/" dirs))
                   k8s/collect-logs! (fn [_ opts]
-                                      (swap! selectors conj opts))]
+                                      (swap! requests conj opts))]
       (#'cluster/get-logs {} backend-db))
-    @selectors))
+    @requests))
+
+(def cluster-logs
+  {:selector "app.kubernetes.io/app=scalardb-cluster" :output-dir "pods"})
+
+(def chaos-mesh-logs
+  {:namespace "chaos-mesh" :output-dir "pods/chaos-mesh"})
 
 (deftest get-logs-test
-  (testing "collects the cluster node logs and the backend DB logs"
-    (is (= [{:selector "app.kubernetes.io/app=scalardb-cluster"
-             :output-dir "pods"}
-            {:selector {:app "database"} :output-dir "pods"}]
-           (collected-selectors backend-with-logs))))
+  (testing "collects the cluster node, backend DB and Chaos Mesh logs"
+    (is (= [cluster-logs
+            {:selector {:app "database"} :output-dir "pods"}
+            chaos-mesh-logs]
+           (collected-logs backend-with-logs))))
 
-  (testing "collects only the cluster node logs for a backend without pods"
-    (is (= [{:selector "app.kubernetes.io/app=scalardb-cluster"
-             :output-dir "pods"}]
-           (collected-selectors (Object.))))))
+  (testing "skips the backend DB logs for a backend without pods"
+    (is (= [cluster-logs chaos-mesh-logs]
+           (collected-logs (Object.)))))
+
+  (testing "keeps collecting when one of the requests fails"
+    (with-redefs [store/path! (fn [_ & dirs] (str/join "/" dirs))
+                  k8s/collect-logs! (fn [_ _] (throw (ex-info "boom" {})))]
+      (is (nil? (#'cluster/get-logs {} backend-with-logs))))))
 
 (deftest nemesis-options-test
   (testing "adds backend-specific options for the file-io nemesis"

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -115,3 +115,35 @@
       (is (empty? (annotated-services {:name "scalardb-transfer" :lb-internet-facing false}
                                       "postgresql-scalardb-cluster"
                                       services))))))
+
+(def file-io-options
+  {:volume-path "/var/lib/database"
+   :file-path "/var/lib/database/**/*"
+   :pod-selector {:app "database"}
+   :container-names ["database"]})
+
+(def backend-with-file-options
+  (reify
+    cluster-db/ClusterDbFileOptions
+    (file-io-options [_] file-io-options)))
+
+(deftest nemesis-options-test
+  (testing "adds backend-specific options for the file-io nemesis"
+    (is (= {:file-io file-io-options}
+           (#'cluster/nemesis-options backend-with-file-options
+                                      :postgres
+                                      [:file-io]))))
+
+  (testing "does not require file options for other nemeses"
+    (is (= {}
+           (#'cluster/nemesis-options (Object.) :managed [:kill]))))
+
+  (testing "rejects file I/O faults for a backend without file options"
+    (let [exception (try
+                      (#'cluster/nemesis-options
+                       (Object.) :managed [:file-io])
+                      nil
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (= "Backend does not support the file-io nemesis"
+             (ex-message exception)))
+      (is (= {:db :managed} (ex-data exception))))))

--- a/scalardb/test/scalardb/db/cluster_test.clj
+++ b/scalardb/test/scalardb/db/cluster_test.clj
@@ -1,6 +1,7 @@
 (ns scalardb.db.cluster-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen.k8s.core :as k8s]
+            [jepsen.store :as store]
             [scalardb.db.cluster :as cluster]
             [scalardb.db.cluster-db.cluster-db :as cluster-db]
             [spy.core :as spy]))
@@ -126,6 +127,33 @@
   (reify
     cluster-db/ClusterDbFileOptions
     (file-io-options [_] file-io-options)))
+
+(def backend-with-logs
+  (reify
+    cluster-db/ClusterDbLogs
+    (log-selector [_] {:app "database"})))
+
+(defn- collected-selectors
+  "Runs get-logs with a mocked k8s, returning the selectors it collected."
+  [backend-db]
+  (let [selectors (atom [])]
+    (with-redefs [store/path! (fn [_ dir] dir)
+                  k8s/collect-logs! (fn [_ opts]
+                                      (swap! selectors conj opts))]
+      (#'cluster/get-logs {} backend-db))
+    @selectors))
+
+(deftest get-logs-test
+  (testing "collects the cluster node logs and the backend DB logs"
+    (is (= [{:selector "app.kubernetes.io/app=scalardb-cluster"
+             :output-dir "pods"}
+            {:selector {:app "database"} :output-dir "pods"}]
+           (collected-selectors backend-with-logs))))
+
+  (testing "collects only the cluster node logs for a backend without pods"
+    (is (= [{:selector "app.kubernetes.io/app=scalardb-cluster"
+             :output-dir "pods"}]
+           (collected-selectors (Object.))))))
 
 (deftest nemesis-options-test
   (testing "adds backend-specific options for the file-io nemesis"


### PR DESCRIPTION
## Description
Give file-related info for each backend DB to the nemesis with Chaos Mesh.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made
- Give the option for file IO nemesis to `nemesis-package`
- Add `ClusterDbFileOptions` for file IO nemesis

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
